### PR TITLE
(#59) RunningInfo Initial/Resume 애니메이션과 print문 삭제 및 타이머 간격 수정

### DIFF
--- a/BoostRunClub.xcodeproj/project.pbxproj
+++ b/BoostRunClub.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9600DB542566AA4400183CB9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9600DB532566AA4400183CB9 /* SceneDelegate.swift */; };
 		9600DB5B2566AA4700183CB9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9600DB5A2566AA4700183CB9 /* Assets.xcassets */; };
 		9600DB5E2566AA4700183CB9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9600DB5C2566AA4700183CB9 /* LaunchScreen.storyboard */; };
+		96015B56257807C100E55E9F /* UIImage+SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96015B55257807C100E55E9F /* UIImage+SFSymbol.swift */; };
 		9635815225722B5B00B8BE6B /* RunDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9635815125722B5B00B8BE6B /* RunDataView.swift */; };
 		9635815525722CFA00B8BE6B /* NikeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9635815425722CFA00B8BE6B /* NikeLabel.swift */; };
 		9635816025726EAB00B8BE6B /* BoostRunClubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9635815F25726EAB00B8BE6B /* BoostRunClubTests.swift */; };
@@ -134,6 +135,7 @@
 		9600DB5A2566AA4700183CB9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9600DB5D2566AA4700183CB9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9600DB5F2566AA4700183CB9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		96015B55257807C100E55E9F /* UIImage+SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SFSymbol.swift"; sourceTree = "<group>"; };
 		9635815125722B5B00B8BE6B /* RunDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunDataView.swift; sourceTree = "<group>"; };
 		9635815425722CFA00B8BE6B /* NikeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NikeLabel.swift; sourceTree = "<group>"; };
 		9635815D25726EAA00B8BE6B /* BoostRunClubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoostRunClubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -370,6 +372,7 @@
 				96FA7DF52570177C00090999 /* CaseIterable+.swift */,
 				967FFAA3257602A200F3340C /* TimerInterval+String.swift */,
 				71EFCCA52577D3E6007998AD /* UIButton+setSFSymbol.swift */,
+				96015B55257807C100E55E9F /* UIImage+SFSymbol.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -566,6 +569,7 @@
 				96FA7E0E2570260E00090999 /* SplitsViewModel.swift in Sources */,
 				71EFCCA62577D3E6007998AD /* UIButton+setSFSymbol.swift in Sources */,
 				71A58D1F256D3FF80012FF51 /* GoalTypeCell.swift in Sources */,
+				96015B56257807C100E55E9F /* UIImage+SFSymbol.swift in Sources */,
 				71E8289B256B9B08004A1F30 /* ActivityViewController.swift in Sources */,
 				71EFCC6E257753FA007998AD /* RunningPageViewModel.swift in Sources */,
 				4CCD6E7F256BEA1200195EDA /* GoalTypeViewController.swift in Sources */,

--- a/BoostRunClub/Extensions/UIButton+setSFSymbol.swift
+++ b/BoostRunClub/Extensions/UIButton+setSFSymbol.swift
@@ -11,8 +11,13 @@ extension UIButton {
     func setSFSymbol(iconName: String, size: CGFloat, weight: UIImage.SymbolWeight = .regular,
                      scale: UIImage.SymbolScale = .default, tintColor: UIColor, backgroundColor: UIColor)
     {
-        let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: size, weight: weight, scale: scale)
-        let buttonImage = UIImage(systemName: iconName, withConfiguration: symbolConfiguration)
+        let buttonImage = UIImage.SFSymbol(
+            name: iconName,
+            size: size,
+            weight: weight,
+            scale: scale,
+            color: tintColor
+        )
         setImage(buttonImage, for: .normal)
         self.tintColor = tintColor
         self.backgroundColor = backgroundColor

--- a/BoostRunClub/Extensions/UIImage+SFSymbol.swift
+++ b/BoostRunClub/Extensions/UIImage+SFSymbol.swift
@@ -1,0 +1,36 @@
+//
+//  UIImage+SFSymbol.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/03.
+//
+
+import UIKit
+
+extension UIImage {
+    static func SFSymbol(
+        name: String,
+        size: CGFloat,
+        weight: UIImage.SymbolWeight,
+        scale: UIImage.SymbolScale,
+        color: UIColor = .label,
+        renderingMode: UIImage.RenderingMode = .automatic
+    ) -> UIImage? {
+        let configuration = UIImage.SymbolConfiguration(pointSize: size, weight: weight, scale: scale)
+        return UIImage.SFSymbol(name: name, configuration: configuration, color: color, renderingMode: renderingMode)
+    }
+
+    static func SFSymbol(
+        name: String,
+        configuration: UIImage.SymbolConfiguration? = nil,
+        color: UIColor = .label,
+        renderingMode: UIImage.RenderingMode = .alwaysOriginal
+    ) -> UIImage? {
+        if let configuration = configuration {
+            return UIImage(systemName: name, withConfiguration: configuration)?
+                .withTintColor(color, renderingMode: renderingMode)
+        } else {
+            return UIImage(systemName: name)?.withTintColor(color, renderingMode: renderingMode)
+        }
+    }
+}

--- a/BoostRunClub/Services/EventTimer.swift
+++ b/BoostRunClub/Services/EventTimer.swift
@@ -20,7 +20,7 @@ class EventTimer: EventTimerProtocol {
     var cancellable: AnyCancellable?
 
     func start() {
-        cancellable = Timer.TimerPublisher(interval: 1, runLoop: RunLoop.main, mode: .default)
+        cancellable = Timer.TimerPublisher(interval: 0.8, runLoop: RunLoop.main, mode: .default)
             .autoconnect()
             .sink { date in
                 self.timeSubject.send(date.timeIntervalSinceReferenceDate)

--- a/BoostRunClub/Services/RunningDataService.swift
+++ b/BoostRunClub/Services/RunningDataService.swift
@@ -14,6 +14,7 @@ protocol RunningDataServiceable {
     var distance: CurrentValueSubject<Double, Never> { get }
     var pace: CurrentValueSubject<Int, Never> { get }
     var avgPace: CurrentValueSubject<Int, Never> { get }
+    var isRunning: Bool { get }
 
     func start()
     func stop()
@@ -36,7 +37,7 @@ class RunningDataService: RunningDataServiceable {
     var avgPace = CurrentValueSubject<Int, Never>(0)
     var distance = CurrentValueSubject<Double, Never>(0)
 
-    var isRunning: Bool = false
+    private(set) var isRunning: Bool = false
     let eventTimer: EventTimerProtocol
 
     init(eventTimer: EventTimerProtocol = EventTimer(), locationProvider: LocationProvidable) {
@@ -85,12 +86,10 @@ class RunningDataService: RunningDataServiceable {
     }
 
     func pause() {
-        eventTimer.stop()
         isRunning = false
     }
 
     func resume() {
-        eventTimer.start()
         isRunning = true
     }
 

--- a/BoostRunClub/ViewModels/PrepareRunViewModelTest.swift
+++ b/BoostRunClub/ViewModels/PrepareRunViewModelTest.swift
@@ -62,7 +62,6 @@ class PrepareRunViewModelTest: XCTestCase {
                 prepareVM.goalTypeSetupClosed
             )
             .sink {
-                print($0)
                 if $0.0 == goalType,
                    $0.1 == goalType.initialValue
                 {
@@ -106,8 +105,7 @@ class PrepareRunViewModelTest: XCTestCase {
             receivedSignal.fulfill()
         }.store(in: &cancellables)
 
-        prepareVM.goalValueObservable.dropFirst().sink {
-            print($0)
+        prepareVM.goalValueObservable.dropFirst().sink {_ in
             XCTFail()
         }.store(in: &cancellables)
 

--- a/BoostRunClub/Views/Cells/GoalTypeCell.swift
+++ b/BoostRunClub/Views/Cells/GoalTypeCell.swift
@@ -54,8 +54,7 @@ class GoalTypeCell: UITableViewCell {
 extension GoalTypeCell {
     private func makeCheckMark() -> UIImageView {
         let view = UIImageView()
-        view.image = UIImage(systemName: "checkmark")?
-            .withTintColor(.label, renderingMode: .alwaysOriginal)
+        view.image = UIImage.SFSymbol(name: "checkmark", color: .label)
         return view
     }
 

--- a/BoostRunClub/Views/Cells/GoalTypeCell.swift
+++ b/BoostRunClub/Views/Cells/GoalTypeCell.swift
@@ -29,12 +29,6 @@ class GoalTypeCell: UITableViewCell {
         commonInit(goalType)
     }
 
-    private func commonInit(_ goalType: GoalType) {
-        selectionStyle = .none
-        goalTypeLabel.text = goalType.description
-        configureLayout()
-    }
-
     func setStyle(with style: Style) {
         switch style {
         case .checked:
@@ -53,6 +47,12 @@ class GoalTypeCell: UITableViewCell {
 // MARK: - Configure
 
 extension GoalTypeCell {
+    private func commonInit(_ goalType: GoalType) {
+        selectionStyle = .none
+        goalTypeLabel.text = goalType.description
+        configureLayout()
+    }
+
     private func makeCheckMark() -> UIImageView {
         let view = UIImageView()
         view.image = UIImage.SFSymbol(name: "checkmark", color: .label)

--- a/BoostRunClub/Views/Cells/GoalTypeCell.swift
+++ b/BoostRunClub/Views/Cells/GoalTypeCell.swift
@@ -8,43 +8,84 @@
 import UIKit
 
 class GoalTypeCell: UITableViewCell {
-    let goalTypeLabel = UILabel()
-    let checkmarkLabel = UILabel()
-    let inset: CGFloat = 20
-    static let cellHeight: CGFloat = 100
+    enum Style {
+        case checked, black, gray
+    }
 
-    var goalType = GoalType.none
+    private let goalTypeLabel = UILabel()
+    private lazy var checkMarkImage = makeCheckMark()
+
+    let goalType: GoalType
 
     required init?(coder: NSCoder) {
+        goalType = .none
         super.init(coder: coder)
+        commonInit(goalType)
     }
 
     init(_ goalType: GoalType) {
-        super.init(style: .default, reuseIdentifier: String(describing: Self.self))
         self.goalType = goalType
+        super.init(style: .default, reuseIdentifier: String(describing: Self.self))
+        commonInit(goalType)
+    }
+
+    private func commonInit(_ goalType: GoalType) {
         goalTypeLabel.text = goalType.description
-        commonInit()
+        configureLayout()
+    }
+
+    func setStyle(with style: Style) {
+        switch style {
+        case .checked:
+            checkMarkImage.isHidden = false
+            goalTypeLabel.textColor = .label
+        case .black:
+            checkMarkImage.isHidden = true
+            goalTypeLabel.textColor = .label
+        case .gray:
+            checkMarkImage.isHidden = true
+            goalTypeLabel.textColor = .systemGray
+        }
     }
 }
 
 // MARK: - Configure
 
 extension GoalTypeCell {
-    private func commonInit() {
-        goalTypeLabel.translatesAutoresizingMaskIntoConstraints = false
-        checkmarkLabel.translatesAutoresizingMaskIntoConstraints = false
+    private func makeCheckMark() -> UIImageView {
+        let view = UIImageView()
+        view.image = UIImage(systemName: "checkmark")?
+            .withTintColor(.label, renderingMode: .alwaysOriginal)
+        return view
+    }
 
+    private func configureLayout() {
         contentView.addSubview(goalTypeLabel)
-        contentView.addSubview(checkmarkLabel)
-
+        goalTypeLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            goalTypeLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: inset),
+            goalTypeLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: LayoutConstant.inset),
             goalTypeLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
         ])
 
+        contentView.addSubview(checkMarkImage)
+        checkMarkImage.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            checkmarkLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -inset),
-            checkmarkLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            checkMarkImage.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -LayoutConstant.inset
+            ),
+            checkMarkImage.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            checkMarkImage.heightAnchor.constraint(equalTo: goalTypeLabel.heightAnchor, multiplier: 1.2),
+            checkMarkImage.widthAnchor.constraint(equalTo: checkMarkImage.heightAnchor),
         ])
+    }
+}
+
+// MARK: - LayoutConstant
+
+extension GoalTypeCell {
+    enum LayoutConstant {
+        static let inset: CGFloat = 20
+        static let cellHeight: CGFloat = 100
     }
 }

--- a/BoostRunClub/Views/Cells/GoalTypeCell.swift
+++ b/BoostRunClub/Views/Cells/GoalTypeCell.swift
@@ -30,6 +30,7 @@ class GoalTypeCell: UITableViewCell {
     }
 
     private func commonInit(_ goalType: GoalType) {
+        selectionStyle = .none
         goalTypeLabel.text = goalType.description
         configureLayout()
     }

--- a/BoostRunClub/Views/CircleButton.swift
+++ b/BoostRunClub/Views/CircleButton.swift
@@ -7,38 +7,12 @@
 
 import UIKit
 
-enum ButtonStyle {
-    case start, stop, pause, resume
-
-    var backgroundColor: UIColor {
-        switch self {
-        case .start:
-            return #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
-        case .stop:
-            return .label
-        case .pause:
-            return .label
-        case .resume:
-            return #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
-        }
-    }
-
-    var title: String {
-        switch self {
-        case .start:
-            return "시작"
-        case .stop:
-            return ""
-        case .pause:
-            return ""
-        case .resume:
-            return ""
-        }
-    }
-}
-
 class CircleButton: UIButton {
-    init(with buttonStyle: ButtonStyle) {
+    enum Style {
+        case start, stop, pause, resume
+    }
+
+    init(with buttonStyle: Style) {
         super.init(frame: .zero)
         commonInit(with: buttonStyle)
     }
@@ -48,7 +22,7 @@ class CircleButton: UIButton {
         commonInit()
     }
 
-    private func commonInit(with buttonStyle: ButtonStyle = .start) {
+    private func commonInit(with buttonStyle: Style = .start) {
         switch buttonStyle {
         case .start:
             backgroundColor = #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)

--- a/BoostRunClub/Views/Controllers/GoalTypeViewController.swift
+++ b/BoostRunClub/Views/Controllers/GoalTypeViewController.swift
@@ -27,8 +27,22 @@ final class GoalTypeViewController: UIViewController {
         viewModel = goalTypeViewModel
     }
 
-    // TODO: goalTypeViewModel에서 선택되어져 있는 값에 체크마크
-    private func bindViewModel() {}
+    private func bindViewModel() {
+        guard let viewModel = viewModel else { return }
+
+        viewModel.outputs.goalTypeObservable
+            .receive(on: RunLoop.main)
+            .sink { goalType in
+                self.tableViewCells.forEach {
+                    if goalType == .none {
+                        $0.setStyle(with: .black)
+                    } else {
+                        $0.setStyle(with: goalType == $0.goalType ? .checked : .gray)
+                    }
+                }
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - ViewController LifeCycle
@@ -133,7 +147,7 @@ extension GoalTypeViewController {
         tableView.register(GoalTypeCell.self, forCellReuseIdentifier: String(describing: GoalTypeCell.self))
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         tableView.layer.cornerRadius = 30
-        tableView.rowHeight = GoalTypeCell.cellHeight
+        tableView.rowHeight = GoalTypeCell.LayoutConstant.cellHeight
         let header = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: verticalTablePadding))
         let footer = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: verticalTablePadding * 2))
         let clearButton = UIButton()
@@ -156,6 +170,6 @@ extension GoalTypeViewController {
     private var verticalTablePadding: CGFloat { 30 }
 
     private var tableViewHeight: CGFloat {
-        CGFloat(tableViewCells.count) * GoalTypeCell.cellHeight + verticalTablePadding * 3
+        CGFloat(tableViewCells.count) * GoalTypeCell.LayoutConstant.cellHeight + verticalTablePadding * 3
     }
 }

--- a/BoostRunClub/Views/RunDataView.swift
+++ b/BoostRunClub/Views/RunDataView.swift
@@ -57,6 +57,28 @@ extension RunDataView {
 // MARK: - Configure
 
 extension RunDataView {
+    private func commonInit() {
+        distribution = .equalSpacing
+        alignment = .center
+        axis = .vertical
+
+        switch style {
+        case .main:
+            valueLabel.font = valueLabel.font.withSize(120)
+            descriptionLabel.font = descriptionLabel.font.withSize(30)
+        case .sub:
+            valueLabel.font = valueLabel.font.withSize(35)
+            descriptionLabel.font = descriptionLabel.font.withSize(20)
+        }
+
+        addArrangedSubview(valueLabel)
+        addArrangedSubview(descriptionLabel)
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(execute))
+
+        addGestureRecognizer(tapGesture)
+    }
+
     private func makeValueLabel() -> UILabel {
         let label: UILabel
         switch style {
@@ -79,27 +101,5 @@ extension RunDataView {
         label.font = UIFont.boldSystemFont(ofSize: 17)
         label.text = "시간"
         return label
-    }
-
-    private func commonInit() {
-        distribution = .equalSpacing
-        alignment = .center
-        axis = .vertical
-
-        switch style {
-        case .main:
-            valueLabel.font = valueLabel.font.withSize(120)
-            descriptionLabel.font = descriptionLabel.font.withSize(30)
-        case .sub:
-            valueLabel.font = valueLabel.font.withSize(35)
-            descriptionLabel.font = descriptionLabel.font.withSize(20)
-        }
-
-        addArrangedSubview(valueLabel)
-        addArrangedSubview(descriptionLabel)
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(execute))
-
-        addGestureRecognizer(tapGesture)
     }
 }


### PR DESCRIPTION
### Issue Number
Close #59

### 변경사항

- `print()` 문 제거
    - print() 문 제거시 test에서 `forEach` 에 변수를 사용하지 않게 되어 `forEach{ _ in}` 처리
- timer 이벤트 간격을 1초로 설정 시 1초를 넘는 이벤트로 인해 2초가 넘어가는 문제 수정
    - timer 이벤트 간격을 1초보다 적은 0.8로 적용
- RunningInfo Initial/Resume 애니메이션을 적용하기 위해 RunningDataProvider와 그 프로토콜에 isRunning 접근자 추가
- RunningInfoVC/VM에 Initial/Resume Subject 추가 및 ViewDidLoad Input 추가

### 새로운 기능

- RunningInfo Initial/Resume 애니메이션
     - Initial시 모든 SubView의 alpha 0 -> 1, scale 0.5 -> 1
     - Resume시 MainDataView alpha 0 -> 1

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
