### PR TITLE
(#117) Activity 타이틀 시간경과에 따라 변경

### DIFF
--- a/BoostRunClub/Extensions/Date+DateRange.swift
+++ b/BoostRunClub/Extensions/Date+DateRange.swift
@@ -63,4 +63,8 @@ extension Date {
         let components = calendar.dateComponents([.weekOfMonth], from: range.start, to: range.end)
         return components.weekOfMonth
     }
+
+    static func isSameWeek(date: Date, dateOfWeek: Date) -> Bool {
+        return dateOfWeek.rangeOfWeek?.contains(date: date) ?? false
+    }
 }

--- a/BoostRunClub/Extensions/Date+String.swift
+++ b/BoostRunClub/Extensions/Date+String.swift
@@ -19,6 +19,10 @@ extension Date {
         DateFormatter.YMDHMFormatter.string(from: self)
     }
 
+    var toYMDString: String {
+        DateFormatter.YMDFormatter.string(from: self)
+    }
+
     var toYMString: String {
         DateFormatter.YMFormatter.string(from: self)
     }
@@ -33,7 +37,7 @@ extension Date {
 
     var yearMonthDay: YearMonthDay? {
         let str = DateFormatter.YMDFormatter.string(from: self)
-        let components = str.components(separatedBy: "-")
+        let components = str.components(separatedBy: ".")
         guard
             components.count >= 3,
             let year = Int(components[0]),

--- a/BoostRunClub/Extensions/DateFormatter+Common.swift
+++ b/BoostRunClub/Extensions/DateFormatter+Common.swift
@@ -34,7 +34,7 @@ extension DateFormatter {
 
     static var YMDFormatter: DateFormatter = {
         let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.dateFormat = "yyyy.MM.dd"
         return fmt
     }()
 

--- a/BoostRunClub/Models/Activity.swift
+++ b/BoostRunClub/Models/Activity.swift
@@ -57,6 +57,12 @@ struct Activity {
     }
 }
 
+extension Activity: Comparable {
+    static func < (lhs: Activity, rhs: Activity) -> Bool {
+        lhs.createdAt < rhs.createdAt
+    }
+}
+
 // ERASE! : dummy 데이터용
 extension Activity {
     init(date: Date) {
@@ -69,12 +75,16 @@ extension Activity {
                   uuid: UUID())
     }
 
-    var weekOfDayText: String {
-        createdAt.toDayOfWeekString
+    var titleText: String {
+        "\(createdAt.toDayOfWeekString) \(createdAt.period) 러닝 "
     }
 
-    var title: String {
-        "\(createdAt.toDayOfWeekString) \(createdAt.period) 러닝 "
+    func dateText(with date: Date) -> String {
+        if Date.isSameWeek(date: createdAt, dateOfWeek: date) {
+            return createdAt.toDayOfWeekString
+        } else {
+            return createdAt.toYMDString
+        }
     }
 
     // TODO: avgPace, distance, time 등 단위 변환이 겹치는 것 공통으로 처리하도록 하기

--- a/BoostRunClub/Models/ActivityFilterType.swift
+++ b/BoostRunClub/Models/ActivityFilterType.swift
@@ -39,31 +39,6 @@ enum ActivityFilterType: Int {
             }
     }
 
-//    func groupDateRanges(from dates: [Date]) -> [DateRange] {
-//        guard !dates.isEmpty else { return [] }
-//
-//        if self == .all {
-//            return [DateRange(start: dates.first!, end: dates.last ?? dates.first!)]
-//        }
-//
-//        var results = [DateRange]()
-//        dates.forEach {
-//            if
-//                results.isEmpty,
-//                let range = $0.rangeOf(type: self)
-//            {
-//                results.append(range)
-//            } else if
-//                let lastRange = results.last,
-//                !lastRange.contains(date: $0),
-//                let newRange = $0.rangeOf(type: self)
-//            {
-//                results.append(newRange)
-//            }
-//        }
-//        return results
-//    }
-
     func rangeDescription(from range: DateRange) -> String {
         switch self {
         case .week:

--- a/BoostRunClub/Models/ActivityFilterType.swift
+++ b/BoostRunClub/Models/ActivityFilterType.swift
@@ -10,30 +10,59 @@ import Foundation
 enum ActivityFilterType: Int {
     case week, month, year, all
 
-    func groupDateRanges(from dates: [Date]) -> [DateRange] {
-        guard !dates.isEmpty else { return [] }
+    func groupDateRanges(from activities: [Activity]) -> [DateRange] {
+        guard !activities.isEmpty else { return [] }
 
         if self == .all {
-            return [DateRange(start: dates.first!, end: dates.last ?? dates.first!)]
+            return [
+                DateRange(
+                    start: activities.first!.createdAt,
+                    end: activities.last?.createdAt ?? activities.first!.createdAt
+                ),
+            ]
         }
 
-        var results = [DateRange]()
-        dates.forEach {
-            if
-                results.isEmpty,
-                let range = $0.rangeOf(type: self)
-            {
-                results.append(range)
-            } else if
-                let lastRange = results.last,
-                !lastRange.contains(date: $0),
-                let newRange = $0.rangeOfWeek
-            {
-                results.append(newRange)
+        return activities
+            .reduce(into: [DateRange]()) { result, activity in
+                if
+                    result.isEmpty,
+                    let range = activity.createdAt.rangeOf(type: self)
+                {
+                    result.append(range)
+                } else if
+                    let lastRange = result.last,
+                    !lastRange.contains(date: activity.createdAt),
+                    let newRange = activity.createdAt.rangeOf(type: self)
+                {
+                    result.append(newRange)
+                }
             }
-        }
-        return results
     }
+
+//    func groupDateRanges(from dates: [Date]) -> [DateRange] {
+//        guard !dates.isEmpty else { return [] }
+//
+//        if self == .all {
+//            return [DateRange(start: dates.first!, end: dates.last ?? dates.first!)]
+//        }
+//
+//        var results = [DateRange]()
+//        dates.forEach {
+//            if
+//                results.isEmpty,
+//                let range = $0.rangeOf(type: self)
+//            {
+//                results.append(range)
+//            } else if
+//                let lastRange = results.last,
+//                !lastRange.contains(date: $0),
+//                let newRange = $0.rangeOf(type: self)
+//            {
+//                results.append(newRange)
+//            }
+//        }
+//        return results
+//    }
 
     func rangeDescription(from range: DateRange) -> String {
         switch self {

--- a/BoostRunClub/ViewModels/ActivityListViewModel.swift
+++ b/BoostRunClub/ViewModels/ActivityListViewModel.swift
@@ -76,8 +76,7 @@ extension ActivityListViewModel: ActivityListViewModelTypes {
 
 extension ActivityListViewModel {
     private func makeActivityListItems(from data: [Activity]) -> [ActivityListItem] {
-        let dates = data.map { $0.createdAt }
-        let ranges = ActivityFilterType.month.groupDateRanges(from: dates)
+        let ranges = ActivityFilterType.month.groupDateRanges(from: data)
         var items = [[Activity]](repeating: [], count: ranges.count)
         data.forEach { activity in
             guard let idx = ranges.firstIndex(where: { $0.contains(date: activity.createdAt) })
@@ -96,6 +95,6 @@ extension ActivityListViewModel {
                 )
                 $0.append(ActivityListItem(total: total, items: listItem))
             }
-            .sorted(by: { $0.total.totalRange.start > $1.total.totalRange.start })
+            .sorted(by: { $0 > $1 })
     }
 }

--- a/BoostRunClub/ViewModels/ActivityViewModel.swift
+++ b/BoostRunClub/ViewModels/ActivityViewModel.swift
@@ -60,10 +60,9 @@ class ActivityViewModel: ActivityViewModelInputs, ActivityViewModelOutputs {
         self.activityProvider = activityProvider
 
         // ERASE! : dummy Data
-        activities = dummyActivity
+        activities = dummyActivity.sorted(by: { $0 > $1 })
 
-        let dates = activities.map { $0.createdAt }
-        ranges[filterTypeSubject.value] = filterTypeSubject.value.groupDateRanges(from: dates)
+        ranges[filterTypeSubject.value] = filterTypeSubject.value.groupDateRanges(from: activities)
 
         let numRecentActivity = activities.count < 5 ? activities.count : 5
         if numRecentActivity > 0 {
@@ -80,11 +79,11 @@ class ActivityViewModel: ActivityViewModelInputs, ActivityViewModelOutputs {
         guard let filterType = ActivityFilterType(rawValue: idx) else { return }
         let ranges = getDateRanges(for: filterType)
 
-        if let latestRange = ranges.last {
+        if let firstRange = ranges.first {
             let total = ActivityTotalConfig(
                 filterType: filterType,
-                filterRange: latestRange,
-                activities: activities.filter { latestRange.contains(date: $0.createdAt) }
+                filterRange: firstRange,
+                activities: activities.filter { firstRange.contains(date: $0.createdAt) }
             )
             filterTypeSubject.send(filterType)
             totalDataSubject.send(total)
@@ -136,8 +135,7 @@ extension ActivityViewModel {
         if self.ranges.contains(where: { $0.key == filter }) {
             ranges = self.ranges[filter]!
         } else {
-            let dates = dummyActivity.compactMap { $0.createdAt }
-            ranges = filter.groupDateRanges(from: dates)
+            ranges = filter.groupDateRanges(from: activities)
             self.ranges[filter] = ranges
         }
         return ranges

--- a/BoostRunClub/ViewModels/CellConfigurable/ActivityListItem.swift
+++ b/BoostRunClub/ViewModels/CellConfigurable/ActivityListItem.swift
@@ -11,3 +11,13 @@ struct ActivityListItem {
     let total: ActivityTotalConfig
     let items: [Activity]
 }
+
+extension ActivityListItem: Comparable {
+    static func == (lhs: ActivityListItem, rhs: ActivityListItem) -> Bool {
+        lhs.total.totalRange.start == rhs.total.totalRange.start
+    }
+
+    static func < (lhs: ActivityListItem, rhs: ActivityListItem) -> Bool {
+        lhs.total.totalRange.start < rhs.total.totalRange.start
+    }
+}

--- a/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
@@ -41,8 +41,8 @@ class ActivityCellView: UICollectionViewCell {
     }
 
     func configure(with activity: Activity) {
-        dateLabel.text = activity.weekOfDayText
-        titleLabel.text = activity.title
+        dateLabel.text = activity.dateText(with: Date())
+        titleLabel.text = activity.titleText
         distanceValueLabel.text = activity.distanceText
         avgPaceValueLabel.text = activity.avgPaceText
         runningTimeValueLabel.text = activity.runningTimeText


### PR DESCRIPTION
### Issue Number
Close #84 , #86 , #117 

### 변경사항
- Date+DateRange
  - 같은 주인지 비교하는 함수 추가
- DateFormatter+
 - "yyyy-mm-dd" 출력형식 "yyyy.mm.dd"로 변경
- ActivityFilterType
 - 기존 group 함수에서 [Date] 를 받던 것 [Activity]를 받도록 변경
- Activity
 - 기존 dateText 를 `getDateText(_ date: Date)` 로 변경해 주입된 날짜와 비교해 date를 표시할 수 있도록 변경
 
### 새로운 기능
- Activity Cell이 표시될 때 
이번주에 속하는 경우 dateLabel을 `~요일` 로 표시
아닐 시 `yyyy.MM.dd`로 표시

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
