### PR TITLE
(#121) 러닝 중단 후 저장시 맵과 경로 스냅샷 저장 기능 구현

### DIFF
--- a/BoostRunClub.xcodeproj/project.pbxproj
+++ b/BoostRunClub.xcodeproj/project.pbxproj
@@ -137,6 +137,9 @@
 		96C468C5257F6D900062AAA4 /* Date+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468C4257F6D900062AAA4 /* Date+String.swift */; };
 		96CB229B25822FE2000D67C4 /* MapSnapShotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */; };
 		96CB22A12582301C000D67C4 /* MKCoordinateRegion+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */; };
+		96CB22A525823284000D67C4 /* RouteSnapShotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22A425823284000D67C4 /* RouteSnapShotProcessor.swift */; };
+		96CB22AB258233BC000D67C4 /* RouteDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22AA258233BC000D67C4 /* RouteDrawer.swift */; };
+		96CB22B525823B02000D67C4 /* MapSnapShotSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22B425823B02000D67C4 /* MapSnapShotSubscription.swift */; };
 		96D7133F2579178600D3D99E /* RunningSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718729412578DA63007BD24F /* RunningSplit.swift */; };
 		96D713422579178800D3D99E /* RunningSlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1EDBF52578E22C004302C5 /* RunningSlice.swift */; };
 		96E0A6A1257EEA79008D81EC /* ActivityDateFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E0A6A0257EEA79008D81EC /* ActivityDateFilterViewController.swift */; };
@@ -279,6 +282,9 @@
 		96C468C4257F6D900062AAA4 /* Date+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+String.swift"; sourceTree = "<group>"; };
 		96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSnapShotService.swift; sourceTree = "<group>"; };
 		96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKCoordinateRegion+Make.swift"; sourceTree = "<group>"; };
+		96CB22A425823284000D67C4 /* RouteSnapShotProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSnapShotProcessor.swift; sourceTree = "<group>"; };
+		96CB22AA258233BC000D67C4 /* RouteDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteDrawer.swift; sourceTree = "<group>"; };
+		96CB22B425823B02000D67C4 /* MapSnapShotSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSnapShotSubscription.swift; sourceTree = "<group>"; };
 		96E0A6A0257EEA79008D81EC /* ActivityDateFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDateFilterViewController.swift; sourceTree = "<group>"; };
 		96E0A6A4257EEAC8008D81EC /* ActivityDateFilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDateFilterViewModel.swift; sourceTree = "<group>"; };
 		96E13211257680B100656476 /* DependencyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyFactory.swift; sourceTree = "<group>"; };
@@ -579,6 +585,9 @@
 			isa = PBXGroup;
 			children = (
 				96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */,
+				96CB22A425823284000D67C4 /* RouteSnapShotProcessor.swift */,
+				96CB22AA258233BC000D67C4 /* RouteDrawer.swift */,
+				96CB22B425823B02000D67C4 /* MapSnapShotSubscription.swift */,
 			);
 			path = MapSnapShotService;
 			sourceTree = "<group>";
@@ -810,11 +819,13 @@
 				4C5874FA257FD88D00185B4C /* RunningSplitCellViewModel.swift in Sources */,
 				714C039E2574F7C6006B81E3 /* SplitsViewCoordinator.swift in Sources */,
 				96ED4035257C768A007DB3DF /* Activity.swift in Sources */,
+				96CB22A525823284000D67C4 /* RouteSnapShotProcessor.swift in Sources */,
 				4C587503257FFF1E00185B4C /* RunningSplitHeaderView.swift in Sources */,
 				4CF009BC257CA9EB00EC928A /* ZActivity+Activity.swift in Sources */,
 				9689A166257640C700DED689 /* PausedRunningViewModel.swift in Sources */,
 				96ED403B257C7747007DB3DF /* CoreDataService.swift in Sources */,
 				71E82892256B9468004A1F30 /* LoginCoordinator.swift in Sources */,
+				96CB22B525823B02000D67C4 /* MapSnapShotSubscription.swift in Sources */,
 				71E82898256B9788004A1F30 /* TabBarCoordinator.swift in Sources */,
 				4CEB6BF2256F657A00FA7E88 /* GoalValueSetupViewController.swift in Sources */,
 				71A58D1C256D2EEA0012FF51 /* GoalTypeViewModel.swift in Sources */,
@@ -829,6 +840,7 @@
 				71EFCC8D2577C3C0007998AD /* CircleButton.swift in Sources */,
 				9635815225722B5B00B8BE6B /* RunDataView.swift in Sources */,
 				964BC6D82580CA0F00A69A82 /* ActivityCellView.swift in Sources */,
+				96CB22AB258233BC000D67C4 /* RouteDrawer.swift in Sources */,
 				96FA7E0E2570260E00090999 /* SplitsViewModel.swift in Sources */,
 				71FBAB0A257D24F8005C8D30 /* Factory+GoalValueSetupScene.swift in Sources */,
 				71FBAAE6257D23DB005C8D30 /* Factory+LoginScene.swift in Sources */,

--- a/BoostRunClub.xcodeproj/project.pbxproj
+++ b/BoostRunClub.xcodeproj/project.pbxproj
@@ -100,6 +100,11 @@
 		963BDEB62572B867001D4124 /* GoalValueSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEB6BF4256F661700FA7E88 /* GoalValueSetupViewModel.swift */; };
 		963BDEB92572B9F4001D4124 /* String+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969D5F1B256FC48000DD11AB /* String+Regex.swift */; };
 		963BDEBA2572B9F4001D4124 /* CaseIterable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FA7DF52570177C00090999 /* CaseIterable+.swift */; };
+		96461B362582BA6000E665B0 /* RouteSnapShotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22A425823284000D67C4 /* RouteSnapShotProcessor.swift */; };
+		96461B372582BA6000E665B0 /* RouteDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22AA258233BC000D67C4 /* RouteDrawer.swift */; };
+		96461B382582BA6000E665B0 /* MapSnapShotSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22B425823B02000D67C4 /* MapSnapShotSubscription.swift */; };
+		96461B392582BA6000E665B0 /* MapSnapShotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */; };
+		96461B3C2582BA6B00E665B0 /* MKCoordinateRegion+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */; };
 		964A0C30257FF2A5008D7FD7 /* Date+DateRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468B4257F58600062AAA4 /* Date+DateRange.swift */; };
 		964A0C31257FF2A5008D7FD7 /* Date+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468C4257F6D900062AAA4 /* Date+String.swift */; };
 		964A0C32257FF2A5008D7FD7 /* DateFormatter+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468BC257F61DA0062AAA4 /* DateFormatter+Common.swift */; };
@@ -934,22 +939,27 @@
 				96B9064A257CE22A0081E8BF /* ZActivityDetail+ActivityDetail.swift in Sources */,
 				4CB8FA3725729F65000B90ED /* GoalValueSetupViewModelTest.swift in Sources */,
 				9635816025726EAB00B8BE6B /* BoostRunClubTests.swift in Sources */,
+				96461B3C2582BA6B00E665B0 /* MKCoordinateRegion+Make.swift in Sources */,
 				96B9063E257CDF630081E8BF /* Activity.swift in Sources */,
 				96B9063B257CDF570081E8BF /* ActivityProvider.swift in Sources */,
 				963BDEB92572B9F4001D4124 /* String+Regex.swift in Sources */,
 				963581762572705200B8BE6B /* LocationProvider.swift in Sources */,
 				9635817C2572707C00B8BE6B /* LocationProviderMock.swift in Sources */,
 				964A0C32257FF2A5008D7FD7 /* DateFormatter+Common.swift in Sources */,
+				96461B382582BA6000E665B0 /* MapSnapShotSubscription.swift in Sources */,
 				96B90644257CDF6F0081E8BF /* Location.swift in Sources */,
 				71CB9FFE2574374B00B1DD04 /* GoalTypeViewModel.swift in Sources */,
 				4C1D49202575D8C4002C66CD /* RunningDataService.swift in Sources */,
+				96461B362582BA6000E665B0 /* RouteSnapShotProcessor.swift in Sources */,
 				96B90641257CDF690081E8BF /* ActivityDetail.swift in Sources */,
 				964A0C35257FF2B5008D7FD7 /* ActivityFilterType.swift in Sources */,
 				96D7133F2579178600D3D99E /* RunningSplit.swift in Sources */,
 				964A0C30257FF2A5008D7FD7 /* Date+DateRange.swift in Sources */,
 				960F9E3A2580FE51008FDA89 /* GoalTypeViewModelTest.swift in Sources */,
+				96461B372582BA6000E665B0 /* RouteDrawer.swift in Sources */,
 				963BDEBA2572B9F4001D4124 /* CaseIterable+.swift in Sources */,
 				964A0C3B257FF2CB008D7FD7 /* TimerInterval+String.swift in Sources */,
+				96461B392582BA6000E665B0 /* MapSnapShotService.swift in Sources */,
 				96D713422579178800D3D99E /* RunningSlice.swift in Sources */,
 				963BDEB62572B867001D4124 /* GoalValueSetupViewModel.swift in Sources */,
 			);

--- a/BoostRunClub.xcodeproj/project.pbxproj
+++ b/BoostRunClub.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		96C468B5257F58600062AAA4 /* Date+DateRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468B4257F58600062AAA4 /* Date+DateRange.swift */; };
 		96C468BD257F61DA0062AAA4 /* DateFormatter+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468BC257F61DA0062AAA4 /* DateFormatter+Common.swift */; };
 		96C468C5257F6D900062AAA4 /* Date+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C468C4257F6D900062AAA4 /* Date+String.swift */; };
+		96CB229B25822FE2000D67C4 /* MapSnapShotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */; };
+		96CB22A12582301C000D67C4 /* MKCoordinateRegion+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */; };
 		96D7133F2579178600D3D99E /* RunningSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718729412578DA63007BD24F /* RunningSplit.swift */; };
 		96D713422579178800D3D99E /* RunningSlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1EDBF52578E22C004302C5 /* RunningSlice.swift */; };
 		96E0A6A1257EEA79008D81EC /* ActivityDateFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E0A6A0257EEA79008D81EC /* ActivityDateFilterViewController.swift */; };
@@ -275,6 +277,8 @@
 		96C468B4257F58600062AAA4 /* Date+DateRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+DateRange.swift"; sourceTree = "<group>"; };
 		96C468BC257F61DA0062AAA4 /* DateFormatter+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Common.swift"; sourceTree = "<group>"; };
 		96C468C4257F6D900062AAA4 /* Date+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+String.swift"; sourceTree = "<group>"; };
+		96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSnapShotService.swift; sourceTree = "<group>"; };
+		96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKCoordinateRegion+Make.swift"; sourceTree = "<group>"; };
 		96E0A6A0257EEA79008D81EC /* ActivityDateFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDateFilterViewController.swift; sourceTree = "<group>"; };
 		96E0A6A4257EEAC8008D81EC /* ActivityDateFilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDateFilterViewModel.swift; sourceTree = "<group>"; };
 		96E13211257680B100656476 /* DependencyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyFactory.swift; sourceTree = "<group>"; };
@@ -524,6 +528,7 @@
 		963B46F3256CD440006138DF /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				96CB229925822FC8000D67C4 /* MapSnapShotService */,
 				4C1D491C2575D869002C66CD /* RunningDataService.swift */,
 				963B46F4256CD4E0006138DF /* LocationProvider.swift */,
 				4C7045FF2577821D009C39A2 /* EventTimer.swift */,
@@ -565,8 +570,17 @@
 				96C468B4257F58600062AAA4 /* Date+DateRange.swift */,
 				96C468BC257F61DA0062AAA4 /* DateFormatter+Common.swift */,
 				96C468C4257F6D900062AAA4 /* Date+String.swift */,
+				96CB22A02582301C000D67C4 /* MKCoordinateRegion+Make.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		96CB229925822FC8000D67C4 /* MapSnapShotService */ = {
+			isa = PBXGroup;
+			children = (
+				96CB229A25822FE2000D67C4 /* MapSnapShotService.swift */,
+			);
+			path = MapSnapShotService;
 			sourceTree = "<group>";
 		};
 		96ED402E257C7633007DB3DF /* CoreData */ = {
@@ -789,6 +803,7 @@
 				4C587510258014C000185B4C /* UIView+identifier.swift in Sources */,
 				96FA7DF62570177C00090999 /* CaseIterable+.swift in Sources */,
 				9689A15E25763CC800DED689 /* PausedRunningViewController.swift in Sources */,
+				96CB229B25822FE2000D67C4 /* MapSnapShotService.swift in Sources */,
 				960A14FA257DFFE4008D2BD3 /* ActivityTableView.swift in Sources */,
 				96C468B5257F58600062AAA4 /* Date+DateRange.swift in Sources */,
 				963865F8257E858D003EEE4B /* ActivityFooterView.swift in Sources */,
@@ -834,6 +849,7 @@
 				71EFCC6E257753FA007998AD /* RunningPageViewModel.swift in Sources */,
 				964BC6E42580CFEE00A69A82 /* ActivityListViewModel.swift in Sources */,
 				71FBAAFA257D2488005C8D30 /* Factory+SplitScene.swift in Sources */,
+				96CB22A12582301C000D67C4 /* MKCoordinateRegion+Make.swift in Sources */,
 				4CCD6E7F256BEA1200195EDA /* GoalTypeViewController.swift in Sources */,
 				4CF009CA257CAE1900EC928A /* ZActivityDetail+ActivityDetail.swift in Sources */,
 				9689A16A2576441900DED689 /* RunningCoordinator.swift in Sources */,

--- a/BoostRunClub/CoreData/BRCModel.xcdatamodeld/BRCModel.xcdatamodel/contents
+++ b/BoostRunClub/CoreData/BRCModel.xcdatamodeld/BRCModel.xcdatamodel/contents
@@ -7,7 +7,7 @@
         <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="elevation" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="thumbnail" optional="YES" attributeType="Binary"/>
-        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="ZActivityDetail" representedClassName="ZActivityDetail" syncable="YES">
         <attribute name="activityUUID" attributeType="UUID" usesScalarValueType="NO"/>
@@ -16,7 +16,6 @@
         <attribute name="calorie" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="elevation" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="locations" attributeType="Binary"/>
-        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="ZRunningSplit" representedClassName="ZRunningSplit" syncable="YES">
         <attribute name="activityUUID" attributeType="UUID" usesScalarValueType="NO"/>
@@ -28,7 +27,7 @@
     </entity>
     <elements>
         <element name="ZActivity" positionX="-63" positionY="-18" width="128" height="134"/>
-        <element name="ZActivityDetail" positionX="-63" positionY="27" width="128" height="134"/>
+        <element name="ZActivityDetail" positionX="-63" positionY="27" width="128" height="119"/>
         <element name="ZRunningSplit" positionX="-63" positionY="54" width="128" height="119"/>
     </elements>
 </model>

--- a/BoostRunClub/CoreData/ZActivityDetail+ActivityDetail.swift
+++ b/BoostRunClub/CoreData/ZActivityDetail+ActivityDetail.swift
@@ -16,7 +16,6 @@ public class ZActivityDetail: NSManagedObject {
     @NSManaged public var calorie: Int32
     @NSManaged public var elevation: Int32
     @NSManaged public var locations: Data?
-    @NSManaged public var uuid: UUID?
 }
 
 extension ZActivityDetail {

--- a/BoostRunClub/Extensions/Date+DateRange.swift
+++ b/BoostRunClub/Extensions/Date+DateRange.swift
@@ -61,7 +61,7 @@ extension Date {
     static func numberOfWeeks(range: DateRange) -> Int? {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.weekOfMonth], from: range.start, to: range.end)
-        return components.weekOfMonth
+        return components.weekOfMonth == 0 ? 1 : components.weekOfMonth
     }
 
     static func isSameWeek(date: Date, dateOfWeek: Date) -> Bool {

--- a/BoostRunClub/Extensions/Date+DateRange.swift
+++ b/BoostRunClub/Extensions/Date+DateRange.swift
@@ -65,10 +65,10 @@ extension Date {
     }
 
     static func isSameWeek(date: Date, dateOfWeek: Date) -> Bool {
-        return dateOfWeek.rangeOfWeek?.contains(date: date) ?? false
+        dateOfWeek.rangeOfWeek?.contains(date: date) ?? false
     }
 
     static func isSameYear(date: Date, dateOfYear: Date) -> Bool {
-        return dateOfYear.rangeOfYear?.contains(date: date) ?? false
+        dateOfYear.rangeOfYear?.contains(date: date) ?? false
     }
 }

--- a/BoostRunClub/Extensions/Date+DateRange.swift
+++ b/BoostRunClub/Extensions/Date+DateRange.swift
@@ -71,12 +71,4 @@ extension Date {
     static func isSameYear(date: Date, dateOfYear: Date) -> Bool {
         dateOfYear.rangeOfYear?.contains(date: date) ?? false
     }
-
-    static func isSameWeek(date: Date, dateOfWeek: Date) -> Bool {
-        return dateOfWeek.rangeOfWeek?.contains(date: date) ?? false
-    }
-
-    static func isSameYear(date: Date, dateOfYear: Date) -> Bool {
-        return dateOfYear.rangeOfYear?.contains(date: date) ?? false
-    }
 }

--- a/BoostRunClub/Extensions/MKCoordinateRegion+Make.swift
+++ b/BoostRunClub/Extensions/MKCoordinateRegion+Make.swift
@@ -1,0 +1,43 @@
+//
+//  MKCoordinateRegion+Make.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/10.
+//
+
+import Foundation
+import MapKit
+
+extension MKCoordinateRegion {
+    static func make(from locations: [CLLocation], offsetRatio: Double = 0.3) -> MKCoordinateRegion {
+        var minLat: CLLocationDegrees = 90.0
+        var maxLat: CLLocationDegrees = -90.0
+        var minLong: CLLocationDegrees = 180.0
+        var maxLong: CLLocationDegrees = -180.0
+
+        locations.forEach {
+            let lat = $0.coordinate.latitude
+            let long = $0.coordinate.longitude
+            minLat = min(lat, minLat)
+            maxLat = max(lat, maxLat)
+            minLong = min(long, minLong)
+            maxLong = max(long, maxLong)
+        }
+
+        let southWest = CLLocation(latitude: minLat, longitude: minLong)
+        let southEast = CLLocation(latitude: minLat, longitude: maxLong)
+        let northEast = CLLocation(latitude: maxLat, longitude: maxLong)
+        let northWest = CLLocation(latitude: maxLat, longitude: minLong)
+
+        let latitudinalMeters = max(southWest.distance(from: northWest), southEast.distance(from: northEast))
+        let longitudinalMeters = max(southWest.distance(from: southEast), northEast.distance(from: northWest))
+
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLong + maxLong) / 2
+        )
+        var delta = max(latitudinalMeters, longitudinalMeters)
+        delta += delta * offsetRatio
+        return MKCoordinateRegion(center: center, latitudinalMeters: delta, longitudinalMeters: delta)
+    }
+}

--- a/BoostRunClub/Factory/DependencyFactory.swift
+++ b/BoostRunClub/Factory/DependencyFactory.swift
@@ -11,9 +11,11 @@ class DependencyFactory {
     lazy var activityProvider = ActivityProvider(coreDataService: coreDataService)
     lazy var locationProvider = LocationProvider()
     lazy var motionProvider = MotionProvider()
+    lazy var mapSnapShotService = MapSnapShotService()
     lazy var runningDataProvider = RunningDataService(
         locationProvider: locationProvider,
         motionProvider: motionProvider,
-        activityWriter: activityProvider
+        activityWriter: activityProvider,
+        mapSnapShotService: mapSnapShotService
     )
 }

--- a/BoostRunClub/Models/ActivityDetail.swift
+++ b/BoostRunClub/Models/ActivityDetail.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ActivityDetail {
-    var activityUUID: UUID?
+    var activityUUID: UUID
     var avgBPM: Int
     var cadence: Int
     var calorie: Int

--- a/BoostRunClub/Services/ActivityProvider.swift
+++ b/BoostRunClub/Services/ActivityProvider.swift
@@ -5,6 +5,7 @@
 //  Created by 김신우 on 2020/12/06.
 //
 
+import Combine
 import CoreData
 import Foundation
 
@@ -14,6 +15,8 @@ protocol ActivityWritable {
 }
 
 protocol ActivityReadable {
+    var activityChangeSignal: PassthroughSubject<Void, Never> { get }
+
     func fetchActivities() -> [Activity]
     func fetchActivityDetail(activityId: UUID) -> ActivityDetail?
     func fetchSplits(activityId: UUID) -> [RunningSplit]
@@ -38,6 +41,7 @@ class ActivityProvider: ActivityWritable, ActivityReadable {
 
         do {
             try coreDataService.context.save()
+            activityChangeSignal.send()
         } catch {
             print(error.localizedDescription)
         }
@@ -90,6 +94,8 @@ class ActivityProvider: ActivityWritable, ActivityReadable {
         }
         return []
     }
+
+    var activityChangeSignal = PassthroughSubject<Void, Never>()
 }
 
 extension ActivityProvider: ActivityManageable {

--- a/BoostRunClub/Services/LocationProvider.swift
+++ b/BoostRunClub/Services/LocationProvider.swift
@@ -49,7 +49,7 @@ extension LocationProvider: CLLocationManagerDelegate {
     func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last,
               location.horizontalAccuracy.sign == .plus,
-              location.verticalAccuracy.sign == .plus,
+//              location.verticalAccuracy.sign == .plus,
               location.speedAccuracy.sign == .plus,
               location.courseAccuracy.sign == .plus
         else { return }

--- a/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
+++ b/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
@@ -1,0 +1,9 @@
+//
+//  MapSnapShotService.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/10.
+//
+
+import Foundation
+

--- a/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
+++ b/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
@@ -10,17 +10,18 @@ import Foundation
 import MapKit
 
 protocol MapSnapShotServiceable {
-    func takeSnapShot(from locations: [CLLocation], size: CGSize) -> AnyPublisher<Data?, Error>
+    func takeSnapShot(from locations: [CLLocation], dimension: Double) -> AnyPublisher<Data?, Error>
 }
 
 class MapSnapShotService: MapSnapShotServiceable {
     func takeSnapShot(
         from locations: [CLLocation],
-        size: CGSize = CGSize(width: 100, height: 100)
+        dimension: Double
     ) -> AnyPublisher<Data?, Error> {
         let region = MKCoordinateRegion.make(from: locations)
         let drawable = RouteDrawer(style: .init(lineWidth: 3, lineColors: [.label]))
         let processor = RouteSnapShotProcessor(locations: locations, drawable: drawable)
+        let size = CGSize(width: dimension, height: dimension)
         return MKMapSnapshotter.Publisher(region: region, size: size, processor: processor)
             .eraseToAnyPublisher()
     }

--- a/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
+++ b/BoostRunClub/Services/MapSnapShotService/MapSnapShotService.swift
@@ -5,5 +5,38 @@
 //  Created by 김신우 on 2020/12/10.
 //
 
+import Combine
 import Foundation
+import MapKit
 
+protocol MapSnapShotServiceable {
+    func takeSnapShot(from locations: [CLLocation], size: CGSize) -> AnyPublisher<Data?, Error>
+}
+
+class MapSnapShotService: MapSnapShotServiceable {
+    func takeSnapShot(
+        from locations: [CLLocation],
+        size: CGSize = CGSize(width: 100, height: 100)
+    ) -> AnyPublisher<Data?, Error> {
+        let region = MKCoordinateRegion.make(from: locations)
+        let drawable = RouteDrawer(style: .init(lineWidth: 3, lineColors: [.label]))
+        let processor = RouteSnapShotProcessor(locations: locations, drawable: drawable)
+        return MKMapSnapshotter.Publisher(region: region, size: size, processor: processor)
+            .eraseToAnyPublisher()
+    }
+}
+
+extension MKMapSnapshotter {
+    // swiftlint:disable:next identifier_name
+    static func Publisher(
+        region: MKCoordinateRegion,
+        size: CGSize,
+        processor: MapSnapShotProcessor
+    ) -> MapSnapShotPublisher {
+        let options = MKMapSnapshotter.Options()
+        options.region = region
+        options.size = size
+        let snapshotter = MKMapSnapshotter(options: options)
+        return MapSnapShotPublisher(snapshotter: snapshotter, processor: processor)
+    }
+}

--- a/BoostRunClub/Services/MapSnapShotService/MapSnapShotSubscription.swift
+++ b/BoostRunClub/Services/MapSnapShotService/MapSnapShotSubscription.swift
@@ -1,0 +1,64 @@
+//
+//  MapSnapShotSubscription.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/10.
+//
+
+import Combine
+import Foundation
+import MapKit
+
+class MapSnapShotSubscription<S: Subscriber>: Subscription where S.Input == Data?, S.Failure == Error {
+    private var subscriber: S?
+    private let snapshotter: MKMapSnapshotter
+    private let processor: MapSnapShotProcessor
+    private let queue = DispatchQueue(label: "MapSnapShot", qos: .background, attributes: .concurrent)
+
+    init(subscriber: S, snapshotter: MKMapSnapshotter, processor: MapSnapShotProcessor) {
+        self.subscriber = subscriber
+        self.snapshotter = snapshotter
+        self.processor = processor
+        start()
+    }
+
+    func request(_: Subscribers.Demand) {}
+
+    func cancel() {
+        snapshotter.cancel()
+        subscriber = nil
+    }
+
+    private func start() {
+        snapshotter.start(with: queue) { [subscriber, processor, queue] snapshot, error in
+            dispatchPrecondition(condition: .onQueue(queue))
+            if let error = error {
+                subscriber?.receive(completion: .failure(error))
+            } else {
+                _ = subscriber?.receive(processor.process(snapShot: snapshot))
+            }
+        }
+    }
+}
+
+struct MapSnapShotPublisher: Publisher {
+    typealias Output = Data?
+    typealias Failure = Error
+
+    private let snapshotter: MKMapSnapshotter
+    private let processor: MapSnapShotProcessor
+
+    init(snapshotter: MKMapSnapshotter, processor: MapSnapShotProcessor) {
+        self.snapshotter = snapshotter
+        self.processor = processor
+    }
+
+    func receive<S>(subscriber: S) where S: Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
+        let subscription = MapSnapShotSubscription(
+            subscriber: subscriber,
+            snapshotter: snapshotter,
+            processor: processor
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}

--- a/BoostRunClub/Services/MapSnapShotService/RouteDrawer.swift
+++ b/BoostRunClub/Services/MapSnapShotService/RouteDrawer.swift
@@ -1,0 +1,61 @@
+//
+//  RouteDrawable.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/10.
+//
+
+import Foundation
+import MapKit
+import UIKit.UIImage
+
+protocol RouteDrawable {
+    func draw(
+        context: CGContext,
+        size: CGSize,
+        locations: [CLLocation],
+        snapshot: MKMapSnapshotter.Snapshot
+    )
+}
+
+struct RouteDrawer: RouteDrawable {
+    struct Style {
+        let lineWidth: CGFloat
+        let lineColors: [UIColor]
+    }
+
+    let style: Style
+
+    func draw(context: CGContext, size: CGSize, locations: [CLLocation], snapshot: MKMapSnapshotter.Snapshot) {
+        guard !style.lineColors.isEmpty else { return }
+
+        context.setLineWidth(style.lineWidth)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+
+        let points = locations.map { snapshot.point(for: $0.coordinate) }
+        let path = CGMutablePath()
+        path.addLines(between: points)
+
+        context.addPath(path)
+        context.replacePathWithStrokedPath()
+        context.clip()
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let colors = [style.lineColors.first!.cgColor, style.lineColors.last!.cgColor] as CFArray
+        guard
+            let gradient = CGGradient(
+                colorsSpace: colorSpace,
+                colors: colors,
+                locations: nil
+            )
+        else { return }
+
+        context.drawLinearGradient(
+            gradient,
+            start: .zero,
+            end: CGPoint(x: size.width, y: size.height),
+            options: []
+        )
+    }
+}

--- a/BoostRunClub/Services/MapSnapShotService/RouteSnapShotProcessor.swift
+++ b/BoostRunClub/Services/MapSnapShotService/RouteSnapShotProcessor.swift
@@ -1,0 +1,51 @@
+//
+//  RouteSnapShotProcessor.swift
+//  BoostRunClub
+//
+//  Created by 김신우 on 2020/12/10.
+//
+
+import Foundation
+import MapKit
+import UIKit.UIImage
+
+protocol MapSnapShotProcessor {
+    func process(snapShot: MKMapSnapshotter.Snapshot?) -> Data?
+}
+
+class RouteSnapShotProcessor: MapSnapShotProcessor {
+    private let drawable: RouteDrawable
+    private let locations: [CLLocation]
+
+    init(locations: [CLLocation], drawable: RouteDrawable) {
+        self.drawable = drawable
+        self.locations = locations
+    }
+
+    func process(snapShot: MKMapSnapshotter.Snapshot?) -> Data? {
+        guard let snapShot = snapShot else { return nil }
+        defer {
+            UIGraphicsEndImageContext()
+        }
+
+        UIGraphicsBeginImageContextWithOptions(snapShot.image.size, false, UIScreen.main.scale)
+
+        snapShot.image.draw(at: .zero)
+
+        guard
+            let context = UIGraphicsGetCurrentContext(),
+            locations.count > 1
+        else {
+            return UIGraphicsGetImageFromCurrentImageContext()?.pngData()
+        }
+
+        drawable.draw(
+            context: context,
+            size: snapShot.image.size,
+            locations: locations,
+            snapshot: snapShot
+        )
+
+        return UIGraphicsGetImageFromCurrentImageContext()?.pngData()
+    }
+}

--- a/BoostRunClub/Services/RunningDataService.swift
+++ b/BoostRunClub/Services/RunningDataService.swift
@@ -135,10 +135,9 @@ class RunningDataService: RunningDataServiceable {
 
         MapSnapShotService().takeSnapShot(from: locations)
             .receive(on: RunLoop.main)
+            .replaceError(with: nil)
             .first()
-            .sink { [weak self] _ in
-                self?.saveRunning(with: nil)
-            } receiveValue: { [weak self] data in
+            .sink { [weak self] data in
                 self?.saveRunning(with: data)
             }
             .store(in: &cancellables)

--- a/BoostRunClub/Services/RunningDataService.swift
+++ b/BoostRunClub/Services/RunningDataService.swift
@@ -34,7 +34,7 @@ protocol RunningDataServiceable {
 
 class RunningDataService: RunningDataServiceable {
     var locationProvider: LocationProvidable
-
+    var mapSnapShotService: MapSnapShotServiceable
     var activityWriter: ActivityWritable
 
     var cancellables = Set<AnyCancellable>()
@@ -70,13 +70,15 @@ class RunningDataService: RunningDataServiceable {
         eventTimer: EventTimerProtocol = EventTimer(),
         locationProvider: LocationProvidable,
         motionProvider: MotionProvider,
-        activityWriter: ActivityWritable
+        activityWriter: ActivityWritable,
+        mapSnapShotService: MapSnapShotServiceable
     ) {
         motionProvider.startUpdating()
 
         self.eventTimer = eventTimer
         self.locationProvider = locationProvider
         self.activityWriter = activityWriter
+        self.mapSnapShotService = mapSnapShotService
 
         locationProvider.locationSubject
             .receive(on: RunLoop.main)
@@ -133,7 +135,7 @@ class RunningDataService: RunningDataServiceable {
         eventTimer.stop()
         endTime = Date()
 
-        MapSnapShotService().takeSnapShot(from: locations)
+        mapSnapShotService.takeSnapShot(from: locations, dimension: 100)
             .receive(on: RunLoop.main)
             .replaceError(with: nil)
             .first()

--- a/BoostRunClub/Services/RunningDataService.swift
+++ b/BoostRunClub/Services/RunningDataService.swift
@@ -133,20 +133,24 @@ class RunningDataService: RunningDataServiceable {
         eventTimer.stop()
         endTime = Date()
         let uuid = UUID()
-        let activity = Activity(avgPace: avgPace.value,
-                                distance: distance.value,
-                                duration: runningTime.value,
-                                elevation: 0, // TODO: elevation 값 저장
-                                thumbnail: nil,
-                                createdAt: startTime,
-                                uuid: uuid)
+        let activity = Activity(
+            avgPace: avgPace.value,
+            distance: distance.value,
+            duration: runningTime.value,
+            elevation: 0, // TODO: elevation 값 저장
+            thumbnail: nil,
+            createdAt: startTime,
+            uuid: uuid
+        )
 
-        let activityDetail = ActivityDetail(activityUUID: uuid,
-                                            avgBPM: 0,
-                                            cadence: cadence.value,
-                                            calorie: Int(calorie.value),
-                                            elevation: 0,
-                                            locations: locations.map { Location(clLocation: $0) })
+        let activityDetail = ActivityDetail(
+            activityUUID: uuid,
+            avgBPM: 0,
+            cadence: cadence.value,
+            calorie: Int(calorie.value),
+            elevation: 0,
+            locations: locations.map { Location(clLocation: $0) }
+        )
         let splits: [RunningSplit] = runningSplits.map {
             var split = $0
             split.activityUUID = uuid

--- a/BoostRunClub/ViewModels/ActivityListViewModel.swift
+++ b/BoostRunClub/ViewModels/ActivityListViewModel.swift
@@ -46,7 +46,8 @@ class ActivityListViewModel: ActivityListViewModelInputs, ActivityListViewModelO
         self.activityProvider = activityProvider
 
         // ERASE!: DummyData
-        let listItems = makeActivityListItems(from: dummyActivity)
+        let activites = activityProvider.fetchActivities()
+        let listItems = makeActivityListItems(from: activites)
         activityListItemSubject.send(listItems)
     }
 

--- a/BoostRunClub/ViewModels/ActivityViewModel.swift
+++ b/BoostRunClub/ViewModels/ActivityViewModel.swift
@@ -65,19 +65,16 @@ class ActivityViewModel: ActivityViewModelInputs, ActivityViewModelOutputs {
 
     private var activities = [Activity]()
     private var ranges = [ActivityFilterType: [DateRange]]()
+    var cancellables = Set<AnyCancellable>()
 
     init(activityProvider: ActivityReadable) {
         self.activityProvider = activityProvider
+        activityProvider.activityChangeSignal
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.fetchActivities() }
+            .store(in: &cancellables)
 
-        // ERASE! : dummy Data
-        activities = activityProvider.fetchActivities().sorted(by: { $0 > $1 })
-
-        ranges[filterTypeSubject.value] = filterTypeSubject.value.groupDateRanges(from: activities)
-
-        let numRecentActivity = activities.count < 5 ? activities.count : 5
-        if numRecentActivity > 0 {
-            recentActivitiesSubject.send(activities[0 ..< numRecentActivity].map { $0 })
-        }
+        fetchActivities()
     }
 
     // Inputs
@@ -140,6 +137,17 @@ extension ActivityViewModel: ActivityViewModelTypes {
 // MARK: - Private Functions
 
 extension ActivityViewModel {
+    private func fetchActivities() {
+        activities = activityProvider.fetchActivities().sorted(by: >)
+
+        ranges[filterTypeSubject.value] = filterTypeSubject.value.groupDateRanges(from: activities)
+
+        let numRecentActivity = activities.count < 5 ? activities.count : 5
+        if numRecentActivity > 0 {
+            recentActivitiesSubject.send(activities[0 ..< numRecentActivity].map { $0 })
+        }
+    }
+
     private func getDateRanges(for filter: ActivityFilterType) -> [DateRange] {
         let ranges: [DateRange]
         if self.ranges.contains(where: { $0.key == filter }) {

--- a/BoostRunClub/ViewModels/ActivityViewModel.swift
+++ b/BoostRunClub/ViewModels/ActivityViewModel.swift
@@ -70,7 +70,7 @@ class ActivityViewModel: ActivityViewModelInputs, ActivityViewModelOutputs {
         self.activityProvider = activityProvider
 
         // ERASE! : dummy Data
-        activities = dummyActivity.sorted(by: { $0 > $1 })
+        activities = activityProvider.fetchActivities().sorted(by: { $0 > $1 })
 
         ranges[filterTypeSubject.value] = filterTypeSubject.value.groupDateRanges(from: activities)
 

--- a/BoostRunClub/ViewModels/CellConfigurable/ActivityTotalConfig.swift
+++ b/BoostRunClub/ViewModels/CellConfigurable/ActivityTotalConfig.swift
@@ -37,7 +37,7 @@ struct ActivityTotalConfig {
 
     // Statistic
     var numRunningPerWeekText: String {
-        let numberOfWeeks = Date.numberOfWeeks(range: totalRange) ?? 1
+        var numberOfWeeks = Date.numberOfWeeks(range: totalRange) ?? 1
         return String(format: "%.2f러닝/주", Double(numRunning) / Double(numberOfWeeks))
     }
 
@@ -58,7 +58,7 @@ struct ActivityTotalConfig {
     init(
         period: String = "",
         distance: Double = 0,
-        numRunning: Int = 1,
+        numRunning: Int = 0,
         avgPace: Int = 0,
         runningTime: Double = 0,
         elevation: Double = 0,
@@ -76,7 +76,6 @@ struct ActivityTotalConfig {
     }
 
     init(filterType: ActivityFilterType, filterRange: DateRange, activities: [Activity]) {
-        var divider = activities.count == 0 ? activities.count : 1
         var sumAvgPace: Int = 0
         var sumDuration: Double = 0
         var sumDistance: Double = 0
@@ -91,7 +90,7 @@ struct ActivityTotalConfig {
         self.filterType = filterType
         selectedRange = filterRange
         period = filterType.rangeDescription(at: filterRange)
-        avgPace = sumAvgPace / divider
+        avgPace = activities.count == 0 ? 0 : sumAvgPace / activities.count
         totalDistance = sumDistance
         totalRunningTime = sumDuration
         numRunning = activities.count

--- a/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
@@ -31,8 +31,6 @@ class ActivityCellView: UICollectionViewCell {
     override func preferredLayoutAttributesFitting(
         _ layoutAttributes: UICollectionViewLayoutAttributes
     ) -> UICollectionViewLayoutAttributes {
-        setNeedsLayout()
-        layoutIfNeeded()
         let size = contentView.systemLayoutSizeFitting(layoutAttributes.size)
         var newFrame = layoutAttributes.frame
         newFrame.size.height = ceil(size.height)
@@ -46,6 +44,8 @@ class ActivityCellView: UICollectionViewCell {
         distanceValueLabel.text = activity.distanceText
         avgPaceValueLabel.text = activity.avgPaceText
         runningTimeValueLabel.text = activity.runningTimeText
+        guard let data = activity.thumbnail else { return }
+        thumbnailImage.image = UIImage(data: data)
     }
 }
 

--- a/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
@@ -42,20 +42,25 @@ class ActivityTotalView: UIView {
         numRunningValueLabel.text = config.numRunningText
         avgPaceValueLabel.text = config.avgPaceText
         runningTimeValueLabel.text = config.totalRunningTimeText
+        
+        let buttonEnable: Bool
         switch config.filterType {
         case .year, .month, .week:
+            buttonEnable = config.numRunning > 0 ? true : false
+        case .all:
+            buttonEnable = false
+        }
+        
+        if buttonEnable {
             dateButton.setImage(dateButtonActiveIcon, for: .normal)
             actionSendable = true
-        case .all:
+        } else {
             dateButton.setImage(dateButtonDeActiveIcon, for: .normal)
             actionSendable = false
         }
     }
 
     func selfResizing() {
-        setNeedsLayout()
-        layoutIfNeeded()
-
         let height = systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
         frame.size.height = height
     }
@@ -138,6 +143,7 @@ extension ActivityTotalView {
             distribution: .fill,
             spacing: 15
         )
+        
         addSubview(vStackView)
         vStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
@@ -42,7 +42,7 @@ class ActivityTotalView: UIView {
         numRunningValueLabel.text = config.numRunningText
         avgPaceValueLabel.text = config.avgPaceText
         runningTimeValueLabel.text = config.totalRunningTimeText
-        
+
         let buttonEnable: Bool
         switch config.filterType {
         case .year, .month, .week:
@@ -50,7 +50,7 @@ class ActivityTotalView: UIView {
         case .all:
             buttonEnable = false
         }
-        
+
         if buttonEnable {
             dateButton.setImage(dateButtonActiveIcon, for: .normal)
             actionSendable = true
@@ -143,7 +143,7 @@ extension ActivityTotalView {
             distribution: .fill,
             spacing: 15
         )
-        
+
         addSubview(vStackView)
         vStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([


### PR DESCRIPTION
### Issue Number
Close #117 #74

### 변경사항
- extension: MKCoordinateRegion 
   - Running의 Coordinators들로 스냅샷을 위한 맵 범위 지정
- MapSnapShotService
   - MKMapSnapShotter를 wraping해 비동기 결과를 Publishing
- MapSnapShotSubscription
   - MKMapSnapShotter의 기존 snapShot은 CompletionHandler를 등록해야 하는데
커스텀 Subscription과 Publisher를 구현해 완료 결과를 옵저빙 할 수 있도록 커스텀 Publisher Subscriber 구현
- RouteSnapShotProcessor
   - SnapShot을 수행하는 Processor로 이미지를 그리기위해 필요한 기본 작업이 수행되는 클래스
설정된 Region을 통해 먼저 이미지의 배경을 지도화면으로 변경한 후
등록된 Drawable로 경로를 그리는 작업을 수행한다.
UIGraphicsBeginImageContextWithOptions를 시작하고 끝낸다.
- RouteDrawer
   - 이미지 바탕 위에 경로를 그려주는 역할을 한다.

### 새로운 기능

- 러닝 중단시 해당 러닝에대한 스냅샷을 기록하고 저장하는 기능

### 참고자료
- [Velik](https://github.com/avdyushin/Velik) 의 mapSnapShot 구조

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
