### PR TITLE
(#129) feat: edit profile scene scrollview으로 교체

### DIFF
--- a/BoostRunClub/Models/Profile.swift
+++ b/BoostRunClub/Models/Profile.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Profile {
+struct Profile: Equatable {
     var image: Data?
     var lastName: String
     var firstName: String

--- a/BoostRunClub/Views/Controllers/EditProfileViewController.swift
+++ b/BoostRunClub/Views/Controllers/EditProfileViewController.swift
@@ -363,7 +363,6 @@ extension EditProfileViewController {
             scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            scrollView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor),
         ])
 
         // MARK: ContentView AutoLayout

--- a/BoostRunClub/Views/Controllers/EditProfileViewController.swift
+++ b/BoostRunClub/Views/Controllers/EditProfileViewController.swift
@@ -9,8 +9,8 @@ import Combine
 import UIKit
 
 final class EditProfileViewController: UIViewController, UINavigationControllerDelegate {
-    private lazy var scrollView = UIScrollView()
-    private lazy var contentView = UIView()
+    private lazy var scrollView: UIScrollView = UIScrollView()
+    private lazy var contentView: UIView = UIView()
     private lazy var navBar: UINavigationBar = makeNavigationBar()
     private lazy var navItem: UINavigationItem = makeNavigationItem()
     private lazy var imageView: UIImageView = makeImageView()
@@ -29,44 +29,44 @@ final class EditProfileViewController: UIViewController, UINavigationControllerD
                                                                          action: #selector(didTapOpenImagePicker))
     private lazy var editLabelGestureRecognizer = UITapGestureRecognizer(target: self,
                                                                          action: #selector(didTapOpenImagePicker))
-
+    
     private var viewModel: EditProfileViewModelTypes?
     private var cancellables = Set<AnyCancellable>()
-
+    
     init(with viewModel: EditProfileViewModelTypes?) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
     }
-
+    
     // TODO: Editprofile viewmodel input의 view did laod 함수 바인딩하기. 아래 바인딩 함수는 뭐하는 녀석인지 판단후 다시 정리하기
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-
+    
     func bindViewModel() {
         guard let viewModel = viewModel else { return }
-
+        
         viewModel.outputs.firstNameTextObservable
             .receive(on: RunLoop.main)
             .sink { text in
                 self.firstNameTextField.text = text
             }
             .store(in: &cancellables)
-
+        
         viewModel.outputs.lastNameTextObservable
             .receive(on: RunLoop.main)
             .sink { text in
                 self.lastNameTextField.text = text
             }
             .store(in: &cancellables)
-
+        
         viewModel.outputs.hometownTextObservable
             .receive(on: RunLoop.main)
             .sink { text in
                 self.hometownTextField.text = text
             }
             .store(in: &cancellables)
-
+        
         viewModel.outputs.bioTextObservable
             .receive(on: RunLoop.main)
             .sink { text in
@@ -74,7 +74,7 @@ final class EditProfileViewController: UIViewController, UINavigationControllerD
                 if !text.isEmpty { self.bioTextView.textColor = .label }
             }
             .store(in: &cancellables)
-
+        
         viewModel.outputs.imageDataObservable
             .receive(on: RunLoop.main)
             .sink { imageData in
@@ -86,7 +86,7 @@ final class EditProfileViewController: UIViewController, UINavigationControllerD
             }
             .store(in: &cancellables)
     }
-
+    
     deinit {
         print("[\(Date())] 🍎ViewController🍏 \(Self.self) deallocated.")
     }
@@ -102,8 +102,7 @@ extension EditProfileViewController {
         configureLayout()
         bindViewModel()
         viewModel?.inputs.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        registerKeyboardNotifications()
     }
 }
 
@@ -114,30 +113,48 @@ extension EditProfileViewController {
         guard let userInfo = notification.userInfo,
               var keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
         else { return }
-
+        
         var contentInset: UIEdgeInsets = scrollView.contentInset
         contentInset.bottom = keyboardFrame.size.height
         scrollView.contentInset = contentInset
     }
-
+    
     @objc func keyboardWillHide(notification _: NSNotification) {
         let contentInset = UIEdgeInsets.zero
         scrollView.contentInset = contentInset
     }
-
+    
     @objc
     private func didTapCancelButton() {
         dismiss(animated: true, completion: nil)
     }
-
+    
     @objc
     private func didTapApplyButton() {
         viewModel?.inputs.didTapApplyButton()
     }
-
+    
     @objc
     private func didTapOpenImagePicker(_: UITapGestureRecognizer) {
         present(imagePicker, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Private Functions
+
+extension EditProfileViewController {
+    private func registerKeyboardNotifications () {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
     }
 }
 
@@ -150,11 +167,11 @@ extension EditProfileViewController {
         navBar.setItems([navItem], animated: false)
         return navBar
     }
-
+    
     private func makeNavigationItem() -> UINavigationItem {
         let navItem = UINavigationItem()
         navItem.hidesBackButton = true
-
+        
         let cancelItem = UIBarButtonItem(
             title: "취소",
             style: .plain,
@@ -163,7 +180,7 @@ extension EditProfileViewController {
         )
         cancelItem.tintColor = .label
         navItem.setLeftBarButton(cancelItem, animated: true)
-
+        
         let applyItem = UIBarButtonItem(
             title: "저장",
             style: .plain,
@@ -172,10 +189,10 @@ extension EditProfileViewController {
         )
         applyItem.tintColor = .systemGray2
         navItem.setRightBarButton(applyItem, animated: true)
-
+        
         return navItem
     }
-
+    
     private func makeImageView() -> UIImageView {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
@@ -187,7 +204,7 @@ extension EditProfileViewController {
         imageView.addGestureRecognizer(imageViewGestureRecognizer)
         return imageView
     }
-
+    
     private func makeLabel(withText text: String, gestureRecognizer: UIGestureRecognizer? = nil) -> UILabel {
         let label = EditProfileSceneLabel()
         label.text = text
@@ -197,7 +214,7 @@ extension EditProfileViewController {
         }
         return label
     }
-
+    
     private func makeNameTextField() -> UIView {
         let stackView = UIStackView(arrangedSubviews: [lastNameTextField, firstNameTextField])
         stackView.axis = .vertical
@@ -206,18 +223,18 @@ extension EditProfileViewController {
         stackView.layer.borderWidth = 1
         stackView.layer.borderColor = UIColor.systemGray5.cgColor
         stackView.clipsToBounds = true
-
+        
         lastNameTextField.layer.borderWidth = 1
         lastNameTextField.layer.borderColor = UIColor.systemGray5.cgColor
-
+        
         return stackView
     }
-
+    
     private func makeTextField(
         placeHolder: String,
         borderStyle: UITextField.BorderStyle = .none
     )
-        -> UITextField
+    -> UITextField
     {
         let textField = CustomPaddedTextField()
         textField.delegate = self
@@ -225,7 +242,7 @@ extension EditProfileViewController {
         textField.borderStyle = borderStyle
         return textField
     }
-
+    
     private func makeBioTextView() -> UITextView {
         let bioTextView = UITextView()
         bioTextView.delegate = self
@@ -241,7 +258,7 @@ extension EditProfileViewController {
                                                       right: 15)
         return bioTextView
     }
-
+    
     private func makeImagePicker() -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
         imagePicker.sourceType = .savedPhotosAlbum
@@ -257,7 +274,7 @@ extension EditProfileViewController: UIImagePickerControllerDelegate {
         guard let selectedImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {
             fatalError("error while retrieving image info")
         }
-
+        
         imageView.image = selectedImage
         guard let imageData = selectedImage.pngData() else {
             fatalError("error while encoding image to png data")
@@ -289,14 +306,14 @@ extension EditProfileViewController: UITextViewDelegate {
             textView.textColor = UIColor.black
         }
     }
-
+    
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = "150자"
             textView.textColor = UIColor.lightGray
         }
     }
-
+    
     func textViewDidChange(_ textView: UITextView) {
         viewModel?.inputs.didEditBio(to: textView.text ?? "")
         if !textView.text.isEmpty {
@@ -309,6 +326,8 @@ extension EditProfileViewController: UITextViewDelegate {
 
 extension EditProfileViewController {
     private func configureLayout() {
+        // MARK: ScrollView AutoLayout
+        
         view.addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -318,7 +337,9 @@ extension EditProfileViewController {
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             scrollView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor),
         ])
-
+        
+        // MARK: ContentView AutoLayout
+        
         scrollView.addSubview(contentView)
         contentView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -328,9 +349,9 @@ extension EditProfileViewController {
             contentView.widthAnchor.constraint(equalTo: view.widthAnchor),
             contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
         ])
-
+        
         // MARK: NavigationBar AutoLayout
-
+        
         view.addSubview(navBar)
         navBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -338,9 +359,9 @@ extension EditProfileViewController {
             navBar.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             navBar.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
         ])
-
+        
         // MARK: ImageView AutoLayout
-
+        
         contentView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -349,18 +370,18 @@ extension EditProfileViewController {
             imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 100),
         ])
-
+        
         // MARK: EditLabel AutoLayout
-
+        
         contentView.addSubview(editLabel)
         editLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             editLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             editLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 5),
         ])
-
+        
         // MARK: NameTextField AutoLayout
-
+        
         contentView.addSubview(nameTextFieldView)
         nameTextFieldView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -369,18 +390,18 @@ extension EditProfileViewController {
             nameTextFieldView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             nameTextFieldView.topAnchor.constraint(equalTo: editLabel.bottomAnchor, constant: 50),
         ])
-
+        
         // MARK: NameLabel AutoLayout
-
+        
         contentView.addSubview(nameLabel)
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nameLabel.leadingAnchor.constraint(equalTo: nameTextFieldView.leadingAnchor),
             nameLabel.bottomAnchor.constraint(equalTo: nameTextFieldView.topAnchor, constant: -5),
         ])
-
+        
         // MARK: HomeTownTextField AutoLayout
-
+        
         contentView.addSubview(hometownTextField)
         hometownTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -389,18 +410,18 @@ extension EditProfileViewController {
             hometownTextField.topAnchor.constraint(equalTo: nameTextFieldView.bottomAnchor, constant: 50),
             hometownTextField.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
         ])
-
+        
         // MARK: HomeTownLabel AutoLayout
-
+        
         contentView.addSubview(hometownLabel)
         hometownLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             hometownLabel.leadingAnchor.constraint(equalTo: hometownTextField.leadingAnchor),
             hometownLabel.bottomAnchor.constraint(equalTo: hometownTextField.topAnchor, constant: -5),
         ])
-
+        
         // MARK: BioTextView AutoLayout
-
+        
         contentView.addSubview(bioTextView)
         bioTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -410,9 +431,9 @@ extension EditProfileViewController {
             bioTextView.topAnchor.constraint(equalTo: hometownTextField.bottomAnchor, constant: 50),
             bioTextView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
-
+        
         // MARK: BioLabel AutoLayout
-
+        
         contentView.addSubview(bioLabel)
         bioLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -428,7 +449,7 @@ class EditProfileSceneLabel: UILabel {
         font = UIFont.systemFont(ofSize: 12)
         textColor = .systemGray
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -439,24 +460,24 @@ class CustomPaddedTextField: UITextField {
                                left: 15,
                                bottom: 0,
                                right: 15)
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         font = UIFont.systemFont(ofSize: 14)
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
+    
     override func textRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }
-
+    
     override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }
-
+    
     override func editingRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }

--- a/BoostRunClub/Views/Controllers/EditProfileViewController.swift
+++ b/BoostRunClub/Views/Controllers/EditProfileViewController.swift
@@ -9,8 +9,8 @@ import Combine
 import UIKit
 
 final class EditProfileViewController: UIViewController, UINavigationControllerDelegate {
-    private lazy var scrollView: UIScrollView = UIScrollView()
-    private lazy var contentView: UIView = UIView()
+    private lazy var scrollView = UIScrollView()
+    private lazy var contentView = UIView()
     private lazy var navBar: UINavigationBar = makeNavigationBar()
     private lazy var navItem: UINavigationItem = makeNavigationItem()
     private lazy var imageView: UIImageView = makeImageView()
@@ -29,64 +29,77 @@ final class EditProfileViewController: UIViewController, UINavigationControllerD
                                                                          action: #selector(didTapOpenImagePicker))
     private lazy var editLabelGestureRecognizer = UITapGestureRecognizer(target: self,
                                                                          action: #selector(didTapOpenImagePicker))
-    
+
     private var viewModel: EditProfileViewModelTypes?
     private var cancellables = Set<AnyCancellable>()
-    
+
     init(with viewModel: EditProfileViewModelTypes?) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
     }
-    
+
     // TODO: Editprofile viewmodel input의 view did laod 함수 바인딩하기. 아래 바인딩 함수는 뭐하는 녀석인지 판단후 다시 정리하기
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
+
     func bindViewModel() {
         guard let viewModel = viewModel else { return }
-        
+
         viewModel.outputs.firstNameTextObservable
             .receive(on: RunLoop.main)
-            .sink { text in
-                self.firstNameTextField.text = text
+            .sink { [weak self] text in
+                self?.firstNameTextField.text = text
             }
             .store(in: &cancellables)
-        
+
         viewModel.outputs.lastNameTextObservable
             .receive(on: RunLoop.main)
-            .sink { text in
-                self.lastNameTextField.text = text
+            .sink { [weak self] text in
+                self?.lastNameTextField.text = text
             }
             .store(in: &cancellables)
-        
+
         viewModel.outputs.hometownTextObservable
             .receive(on: RunLoop.main)
-            .sink { text in
-                self.hometownTextField.text = text
+            .sink { [weak self] text in
+                self?.hometownTextField.text = text
             }
             .store(in: &cancellables)
-        
+
         viewModel.outputs.bioTextObservable
             .receive(on: RunLoop.main)
-            .sink { text in
-                self.bioTextView.text = text
-                if !text.isEmpty { self.bioTextView.textColor = .label }
+            .sink { [weak self] text in
+                self?.bioTextView.text = text
+                if !text.isEmpty { self?.bioTextView.textColor = .label }
             }
             .store(in: &cancellables)
-        
+
         viewModel.outputs.imageDataObservable
             .receive(on: RunLoop.main)
-            .sink { imageData in
+            .sink { [weak self] imageData in
                 if let imageData = imageData {
-                    self.imageView.image = UIImage(data: imageData)
+                    self?.imageView.image = UIImage(data: imageData)
                 } else {
-                    self.imageView.image = UIImage.SFSymbol(name: "person.circle", color: .gray)
+                    self?.imageView.image = UIImage.SFSymbol(name: "person.circle", color: .gray)
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.outputs.changeInContentSignal
+            .receive(on: RunLoop.main)
+            .sink { [weak self] (bool: Bool) in
+                if bool {
+                    self?.navItem.rightBarButtonItem?.tintColor = .label
+                    self?.navItem.rightBarButtonItem?.isEnabled = true
+                } else {
+                    self?.navItem.rightBarButtonItem?.tintColor = .gray
+                    self?.navItem.rightBarButtonItem?.isEnabled = false
                 }
             }
             .store(in: &cancellables)
     }
-    
+
     deinit {
         print("[\(Date())] 🍎ViewController🍏 \(Self.self) deallocated.")
     }
@@ -113,27 +126,27 @@ extension EditProfileViewController {
         guard let userInfo = notification.userInfo,
               var keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
         else { return }
-        
+
         var contentInset: UIEdgeInsets = scrollView.contentInset
         contentInset.bottom = keyboardFrame.size.height
         scrollView.contentInset = contentInset
     }
-    
+
     @objc func keyboardWillHide(notification _: NSNotification) {
         let contentInset = UIEdgeInsets.zero
         scrollView.contentInset = contentInset
     }
-    
+
     @objc
     private func didTapCancelButton() {
         dismiss(animated: true, completion: nil)
     }
-    
+
     @objc
     private func didTapApplyButton() {
         viewModel?.inputs.didTapApplyButton()
     }
-    
+
     @objc
     private func didTapOpenImagePicker(_: UITapGestureRecognizer) {
         present(imagePicker, animated: true, completion: nil)
@@ -143,18 +156,20 @@ extension EditProfileViewController {
 // MARK: - Private Functions
 
 extension EditProfileViewController {
-    private func registerKeyboardNotifications () {
+    private func registerKeyboardNotifications() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow),
             name: UIResponder.keyboardWillShowNotification,
-            object: nil)
-        
+            object: nil
+        )
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillHide),
             name: UIResponder.keyboardWillHideNotification,
-            object: nil)
+            object: nil
+        )
     }
 }
 
@@ -167,11 +182,11 @@ extension EditProfileViewController {
         navBar.setItems([navItem], animated: false)
         return navBar
     }
-    
+
     private func makeNavigationItem() -> UINavigationItem {
         let navItem = UINavigationItem()
         navItem.hidesBackButton = true
-        
+
         let cancelItem = UIBarButtonItem(
             title: "취소",
             style: .plain,
@@ -180,7 +195,7 @@ extension EditProfileViewController {
         )
         cancelItem.tintColor = .label
         navItem.setLeftBarButton(cancelItem, animated: true)
-        
+
         let applyItem = UIBarButtonItem(
             title: "저장",
             style: .plain,
@@ -189,10 +204,10 @@ extension EditProfileViewController {
         )
         applyItem.tintColor = .systemGray2
         navItem.setRightBarButton(applyItem, animated: true)
-        
+
         return navItem
     }
-    
+
     private func makeImageView() -> UIImageView {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
@@ -204,7 +219,7 @@ extension EditProfileViewController {
         imageView.addGestureRecognizer(imageViewGestureRecognizer)
         return imageView
     }
-    
+
     private func makeLabel(withText text: String, gestureRecognizer: UIGestureRecognizer? = nil) -> UILabel {
         let label = EditProfileSceneLabel()
         label.text = text
@@ -214,7 +229,7 @@ extension EditProfileViewController {
         }
         return label
     }
-    
+
     private func makeNameTextField() -> UIView {
         let stackView = UIStackView(arrangedSubviews: [lastNameTextField, firstNameTextField])
         stackView.axis = .vertical
@@ -223,18 +238,18 @@ extension EditProfileViewController {
         stackView.layer.borderWidth = 1
         stackView.layer.borderColor = UIColor.systemGray5.cgColor
         stackView.clipsToBounds = true
-        
+
         lastNameTextField.layer.borderWidth = 1
         lastNameTextField.layer.borderColor = UIColor.systemGray5.cgColor
-        
+
         return stackView
     }
-    
+
     private func makeTextField(
         placeHolder: String,
         borderStyle: UITextField.BorderStyle = .none
     )
-    -> UITextField
+        -> UITextField
     {
         let textField = CustomPaddedTextField()
         textField.delegate = self
@@ -242,7 +257,7 @@ extension EditProfileViewController {
         textField.borderStyle = borderStyle
         return textField
     }
-    
+
     private func makeBioTextView() -> UITextView {
         let bioTextView = UITextView()
         bioTextView.delegate = self
@@ -258,7 +273,7 @@ extension EditProfileViewController {
                                                       right: 15)
         return bioTextView
     }
-    
+
     private func makeImagePicker() -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
         imagePicker.sourceType = .savedPhotosAlbum
@@ -274,7 +289,7 @@ extension EditProfileViewController: UIImagePickerControllerDelegate {
         guard let selectedImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {
             fatalError("error while retrieving image info")
         }
-        
+
         imageView.image = selectedImage
         guard let imageData = selectedImage.pngData() else {
             fatalError("error while encoding image to png data")
@@ -297,6 +312,19 @@ extension EditProfileViewController: UITextFieldDelegate {
             return
         }
     }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        switch textField {
+        case lastNameTextField:
+            viewModel?.inputs.didEditLastName(to: textField.text ?? "")
+        case firstNameTextField:
+            viewModel?.inputs.didEditFirstName(to: textField.text ?? "")
+        case hometownTextField:
+            viewModel?.inputs.didEditHometown(to: textField.text ?? "")
+        default:
+            return
+        }
+    }
 }
 
 extension EditProfileViewController: UITextViewDelegate {
@@ -306,14 +334,14 @@ extension EditProfileViewController: UITextViewDelegate {
             textView.textColor = UIColor.black
         }
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = "150자"
             textView.textColor = UIColor.lightGray
         }
     }
-    
+
     func textViewDidChange(_ textView: UITextView) {
         viewModel?.inputs.didEditBio(to: textView.text ?? "")
         if !textView.text.isEmpty {
@@ -327,7 +355,7 @@ extension EditProfileViewController: UITextViewDelegate {
 extension EditProfileViewController {
     private func configureLayout() {
         // MARK: ScrollView AutoLayout
-        
+
         view.addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -337,9 +365,9 @@ extension EditProfileViewController {
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             scrollView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor),
         ])
-        
+
         // MARK: ContentView AutoLayout
-        
+
         scrollView.addSubview(contentView)
         contentView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -349,9 +377,9 @@ extension EditProfileViewController {
             contentView.widthAnchor.constraint(equalTo: view.widthAnchor),
             contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
         ])
-        
+
         // MARK: NavigationBar AutoLayout
-        
+
         view.addSubview(navBar)
         navBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -359,9 +387,9 @@ extension EditProfileViewController {
             navBar.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             navBar.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
         ])
-        
+
         // MARK: ImageView AutoLayout
-        
+
         contentView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -370,18 +398,18 @@ extension EditProfileViewController {
             imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 100),
         ])
-        
+
         // MARK: EditLabel AutoLayout
-        
+
         contentView.addSubview(editLabel)
         editLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             editLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             editLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 5),
         ])
-        
+
         // MARK: NameTextField AutoLayout
-        
+
         contentView.addSubview(nameTextFieldView)
         nameTextFieldView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -390,18 +418,18 @@ extension EditProfileViewController {
             nameTextFieldView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             nameTextFieldView.topAnchor.constraint(equalTo: editLabel.bottomAnchor, constant: 50),
         ])
-        
+
         // MARK: NameLabel AutoLayout
-        
+
         contentView.addSubview(nameLabel)
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nameLabel.leadingAnchor.constraint(equalTo: nameTextFieldView.leadingAnchor),
             nameLabel.bottomAnchor.constraint(equalTo: nameTextFieldView.topAnchor, constant: -5),
         ])
-        
+
         // MARK: HomeTownTextField AutoLayout
-        
+
         contentView.addSubview(hometownTextField)
         hometownTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -410,18 +438,18 @@ extension EditProfileViewController {
             hometownTextField.topAnchor.constraint(equalTo: nameTextFieldView.bottomAnchor, constant: 50),
             hometownTextField.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
         ])
-        
+
         // MARK: HomeTownLabel AutoLayout
-        
+
         contentView.addSubview(hometownLabel)
         hometownLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             hometownLabel.leadingAnchor.constraint(equalTo: hometownTextField.leadingAnchor),
             hometownLabel.bottomAnchor.constraint(equalTo: hometownTextField.topAnchor, constant: -5),
         ])
-        
+
         // MARK: BioTextView AutoLayout
-        
+
         contentView.addSubview(bioTextView)
         bioTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -431,9 +459,9 @@ extension EditProfileViewController {
             bioTextView.topAnchor.constraint(equalTo: hometownTextField.bottomAnchor, constant: 50),
             bioTextView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
-        
+
         // MARK: BioLabel AutoLayout
-        
+
         contentView.addSubview(bioLabel)
         bioLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -449,7 +477,7 @@ class EditProfileSceneLabel: UILabel {
         font = UIFont.systemFont(ofSize: 12)
         textColor = .systemGray
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -460,24 +488,24 @@ class CustomPaddedTextField: UITextField {
                                left: 15,
                                bottom: 0,
                                right: 15)
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         font = UIFont.systemFont(ofSize: 14)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     override func textRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }
-    
+
     override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }
-    
+
     override func editingRect(forBounds bounds: CGRect) -> CGRect {
         bounds.inset(by: padding)
     }

--- a/BoostRunClub/Views/Controllers/EditProfileViewController.swift
+++ b/BoostRunClub/Views/Controllers/EditProfileViewController.swift
@@ -9,6 +9,8 @@ import Combine
 import UIKit
 
 final class EditProfileViewController: UIViewController, UINavigationControllerDelegate {
+    private lazy var scrollView = UIScrollView()
+    private lazy var contentView = UIView()
     private lazy var navBar: UINavigationBar = makeNavigationBar()
     private lazy var navItem: UINavigationItem = makeNavigationItem()
     private lazy var imageView: UIImageView = makeImageView()
@@ -100,12 +102,29 @@ extension EditProfileViewController {
         configureLayout()
         bindViewModel()
         viewModel?.inputs.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 
 // MARK: - Action
 
 extension EditProfileViewController {
+    @objc func keyboardWillShow(notification: NSNotification) {
+        guard let userInfo = notification.userInfo,
+              var keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
+        else { return }
+
+        var contentInset: UIEdgeInsets = scrollView.contentInset
+        contentInset.bottom = keyboardFrame.size.height
+        scrollView.contentInset = contentInset
+    }
+
+    @objc func keyboardWillHide(notification _: NSNotification) {
+        let contentInset = UIEdgeInsets.zero
+        scrollView.contentInset = contentInset
+    }
+
     @objc
     private func didTapCancelButton() {
         dismiss(animated: true, completion: nil)
@@ -290,50 +309,70 @@ extension EditProfileViewController: UITextViewDelegate {
 
 extension EditProfileViewController {
     private func configureLayout() {
+        view.addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor),
+        ])
+
+        scrollView.addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+        ])
+
         // MARK: NavigationBar AutoLayout
 
         view.addSubview(navBar)
         navBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            navBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            navBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            navBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            navBar.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            navBar.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            navBar.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
         ])
 
         // MARK: ImageView AutoLayout
 
-        view.addSubview(imageView)
+        contentView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             imageView.widthAnchor.constraint(equalToConstant: 80),
             imageView.heightAnchor.constraint(equalToConstant: 80),
-            imageView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
-            imageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 100),
+            imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 100),
         ])
 
         // MARK: EditLabel AutoLayout
 
-        view.addSubview(editLabel)
+        contentView.addSubview(editLabel)
         editLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            editLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            editLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             editLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 5),
         ])
 
         // MARK: NameTextField AutoLayout
 
-        view.addSubview(nameTextFieldView)
+        contentView.addSubview(nameTextFieldView)
         nameTextFieldView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nameTextFieldView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, constant: -40),
+            nameTextFieldView.widthAnchor.constraint(equalTo: contentView.widthAnchor, constant: -40),
             nameTextFieldView.heightAnchor.constraint(equalToConstant: 80),
-            nameTextFieldView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            nameTextFieldView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             nameTextFieldView.topAnchor.constraint(equalTo: editLabel.bottomAnchor, constant: 50),
         ])
 
         // MARK: NameLabel AutoLayout
 
-        view.addSubview(nameLabel)
+        contentView.addSubview(nameLabel)
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nameLabel.leadingAnchor.constraint(equalTo: nameTextFieldView.leadingAnchor),
@@ -342,18 +381,18 @@ extension EditProfileViewController {
 
         // MARK: HomeTownTextField AutoLayout
 
-        view.addSubview(hometownTextField)
+        contentView.addSubview(hometownTextField)
         hometownTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             hometownTextField.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -40),
             hometownTextField.heightAnchor.constraint(equalToConstant: 40),
             hometownTextField.topAnchor.constraint(equalTo: nameTextFieldView.bottomAnchor, constant: 50),
-            hometownTextField.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            hometownTextField.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
         ])
 
         // MARK: HomeTownLabel AutoLayout
 
-        view.addSubview(hometownLabel)
+        contentView.addSubview(hometownLabel)
         hometownLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             hometownLabel.leadingAnchor.constraint(equalTo: hometownTextField.leadingAnchor),
@@ -362,18 +401,19 @@ extension EditProfileViewController {
 
         // MARK: BioTextView AutoLayout
 
-        view.addSubview(bioTextView)
+        contentView.addSubview(bioTextView)
         bioTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             bioTextView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -40),
             bioTextView.heightAnchor.constraint(equalToConstant: 120),
-            bioTextView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            bioTextView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             bioTextView.topAnchor.constraint(equalTo: hometownTextField.bottomAnchor, constant: 50),
+            bioTextView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
 
         // MARK: BioLabel AutoLayout
 
-        view.addSubview(bioLabel)
+        contentView.addSubview(bioLabel)
         bioLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             bioLabel.leadingAnchor.constraint(equalTo: bioTextView.leadingAnchor),


### PR DESCRIPTION
### Issue Number
Close #129

### 변경사항

- EditProfileViewController의 뷰에 Scroll뷰를 더한다.
- 키보드가 올라오면 키보드의 높이와 contentView의 사이즈를 활용하여 스크롤이 되도록한다.
- EditProfileViewModel에 initialProfile 변수를 추가하여 저장되어있던 Profile 값과 다르지 않는 한 저장을 허용하지 않는다
 
### 새로운 기능

- 프로필 수정화면의 뷰가 키보드가 올라왔을 때 스크롤이 되도록 한다.
- 변경사항이 없을 시 저장 버튼을 비활성화한다. 

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
