### PR TITLE
(#142) Style 및 SimpleSplitCellView avgPace별 배경 막대그래프 수치 적용

### DIFF
--- a/BoostRunClub/Coordinators/ActivityDetailCoordinator.swift
+++ b/BoostRunClub/Coordinators/ActivityDetailCoordinator.swift
@@ -37,7 +37,7 @@ final class ActivityDetailCoordinator: BasicCoordinator {
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.navigationController.popViewController(animated: true) }
             .store(in: &cancellables)
-        
+
         navigationController.pushViewController(detailVC, animated: true)
     }
 }

--- a/BoostRunClub/Factory/Extensions/Factory+RunningPageContainer.swift
+++ b/BoostRunClub/Factory/Extensions/Factory+RunningPageContainer.swift
@@ -17,7 +17,10 @@ protocol RunningPageContainerFactory {
 }
 
 extension DependencyFactory: RunningPageContainerFactory {
-    func makeRunningPageVC(with viewModel: RunningPageViewModelTypes, viewControllers: [UIViewController]) -> UIViewController {
+    func makeRunningPageVC(
+        with viewModel: RunningPageViewModelTypes,
+        viewControllers: [UIViewController]
+    ) -> UIViewController {
         RunningPageViewController(with: viewModel, viewControllers: viewControllers)
     }
 

--- a/BoostRunClub/ViewModels/Configurable/ActivityTotalConfig.swift
+++ b/BoostRunClub/ViewModels/Configurable/ActivityTotalConfig.swift
@@ -37,7 +37,7 @@ struct ActivityTotalConfig {
 
     // Statistic
     var numRunningPerWeekText: String {
-        var numberOfWeeks = Date.numberOfWeeks(range: totalRange) ?? 1
+        let numberOfWeeks = Date.numberOfWeeks(range: totalRange) ?? 1
         return String(format: "%.2f러닝/주", Double(numRunning) / Double(numberOfWeeks))
     }
 
@@ -76,7 +76,6 @@ struct ActivityTotalConfig {
     }
 
     init(filterType: ActivityFilterType, filterRange: DateRange, activities: [Activity]) {
-        var divider = activities.count == 0 ? activities.count : 1
         var sumAvgPace: Int = 0
         var sumDuration: Double = 0
         var sumDistance: Double = 0

--- a/BoostRunClub/ViewModels/GoalValueSetupViewModelTest.swift
+++ b/BoostRunClub/ViewModels/GoalValueSetupViewModelTest.swift
@@ -9,6 +9,7 @@
 import Combine
 import XCTest
 
+// swiftlint:disable:next type_body_length
 class GoalValueSetupViewModelTest: XCTestCase {
     override func setUp() {}
 
@@ -475,4 +476,6 @@ class GoalValueSetupViewModelTest: XCTestCase {
             cancel.cancel()
         }
     }
+
+    // swiftlint:disable:next file_length
 }

--- a/BoostRunClub/Views/ActivityDetailScene/DetailTotalView.swift
+++ b/BoostRunClub/Views/ActivityDetailScene/DetailTotalView.swift
@@ -81,6 +81,7 @@ extension DetailTotalView {
         configureLayout()
     }
 
+    // swiftlint:disable:next function_body_length
     private func configureLayout() {
         let distanceVStack = UIStackView.make(
             with: [distanceValueLabel, distancelabel],

--- a/BoostRunClub/Views/ActivityDetailScene/SimpleSplitViewCell.swift
+++ b/BoostRunClub/Views/ActivityDetailScene/SimpleSplitViewCell.swift
@@ -68,6 +68,7 @@ class SimpleSplitViewCell: UITableViewCell {
 
     private func setAvgProgress(to progress: CGFloat) {
         let progress = progress == .nan ? 0 : progress
+        layoutIfNeeded()
         let fullWidth = paceBackgroundView.bounds.width
         let progressWidth = Constant.paceMinWidth + (fullWidth - Constant.paceMinWidth) * progress
         paceContainerWidthConstraint.constant = progressWidth
@@ -94,20 +95,20 @@ extension SimpleSplitViewCell {
 
         NSLayoutConstraint.activate([
             distanceBackgroundView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            distanceBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            distanceBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            distanceBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 2),
+            distanceBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -2),
             distanceBackgroundView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
 
             paceBackgroundView.leadingAnchor.constraint(equalTo: distanceBackgroundView.trailingAnchor),
             paceBackgroundView.trailingAnchor.constraint(equalTo: elevationBackgroundView.leadingAnchor),
-            paceBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            paceBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            paceBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 2),
+            paceBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -2),
 
             elevationBackgroundView.leadingAnchor.constraint(equalTo: paceBackgroundView.trailingAnchor),
             elevationBackgroundView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            elevationBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            elevationBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            elevationBackgroundView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
+            elevationBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 2),
+            elevationBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -2),
+            elevationBackgroundView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.15),
         ])
 
         distanceBackgroundView.addSubview(distanceLabel)

--- a/BoostRunClub/Views/ActivityDetailScene/SimpleSplitViewCell.swift
+++ b/BoostRunClub/Views/ActivityDetailScene/SimpleSplitViewCell.swift
@@ -25,7 +25,8 @@ class SimpleSplitViewCell: UITableViewCell {
     private var elevationLabel = UILabel.makeBold(text: "고도")
     private var elevationBackgroundView = UIView()
 
-    private lazy var paceContainerWidthConstraint = paceForegroundView.widthAnchor.constraint(equalToConstant: Constant.paceMinWidth)
+    private lazy var paceContainerWidthConstraint
+        = paceForegroundView.widthAnchor.constraint(equalToConstant: Constant.paceMinWidth)
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier _: String?) {
         super.init(style: style, reuseIdentifier: "\(SimpleSplitViewCell.self)")
@@ -81,6 +82,7 @@ extension SimpleSplitViewCell {
         configureLayout()
     }
 
+    // swiftlint:disable:next function_body_length
     private func configureLayout() {
         contentView.addSubview(distanceBackgroundView)
         contentView.addSubview(paceBackgroundView)

--- a/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityCellView.swift
@@ -62,6 +62,7 @@ extension ActivityCellView {
         contentView.layer.masksToBounds = true
     }
 
+    // swiftlint:disable:next function_body_length
     private func configureLayout() {
 //        contentView.translatesAutoresizingMaskIntoConstraints = false
         thumbnailImage.translatesAutoresizingMaskIntoConstraints = false

--- a/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
+++ b/BoostRunClub/Views/ActivityScene/ActivityTotalView.swift
@@ -94,6 +94,7 @@ extension ActivityTotalView {
         configureLayout()
     }
 
+    // swiftlint:disable:next function_body_length
     private func configureLayout() {
         translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/BoostRunClub/Views/CircleLongPressButton.swift
+++ b/BoostRunClub/Views/CircleLongPressButton.swift
@@ -47,7 +47,9 @@ class CircleLongPressButton: CircleButton {
 
     func updateProgress(_ progress: CGFloat) {
         let iProgress = 1 - progress
-        let newProgress = 3 * progress * iProgress * iProgress + 3 * progress * progress * iProgress + progress * progress * progress
+        let newProgress = 3 * progress * iProgress * iProgress
+            + 3 * progress * progress * iProgress
+            + progress * progress * progress
 
         let newScaleRatio = 1 + (targetScaleRatio - 1) * newProgress
         transform = CGAffineTransform(scaleX: newScaleRatio, y: newScaleRatio)

--- a/BoostRunClub/Views/Controllers/EditProfileViewController.swift
+++ b/BoostRunClub/Views/Controllers/EditProfileViewController.swift
@@ -124,7 +124,7 @@ extension EditProfileViewController {
 extension EditProfileViewController {
     @objc func keyboardWillShow(notification: NSNotification) {
         guard let userInfo = notification.userInfo,
-              var keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
+              let keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
         else { return }
 
         var contentInset: UIEdgeInsets = scrollView.contentInset
@@ -353,6 +353,7 @@ extension EditProfileViewController: UITextViewDelegate {
 // MARK: - Configure
 
 extension EditProfileViewController {
+    // swiftlint:disable:next function_body_length
     private func configureLayout() {
         // MARK: ScrollView AutoLayout
 

--- a/BoostRunClub/Views/Controllers/PausedRunningViewController.swift
+++ b/BoostRunClub/Views/Controllers/PausedRunningViewController.swift
@@ -162,6 +162,7 @@ extension PausedRunningViewController: MKMapViewDelegate {
 // MARK: - Configure
 
 extension PausedRunningViewController {
+    // swiftlint:disable:next function_body_length
     func configureLayout() {
         view.addSubview(mapView)
         mapView.translatesAutoresizingMaskIntoConstraints = false

--- a/BoostRunClub/Views/Controllers/RunningMapViewController.swift
+++ b/BoostRunClub/Views/Controllers/RunningMapViewController.swift
@@ -29,7 +29,9 @@ class RunningMapViewController: UIViewController {
         guard let viewModel = viewModel else { return }
         viewModel.outputs.routesSubject
             .receive(on: RunLoop.main)
-            .sink { [weak self] routes in self?.mapView.addOverlay(MKPolyline(coordinates: routes, count: routes.count)) }
+            .sink { [weak self] routes in
+                self?.mapView.addOverlay(MKPolyline(coordinates: routes, count: routes.count))
+            }
             .store(in: &cancellables)
 
         viewModel.outputs.userTrackingModeOnWithAnimatedSignal

--- a/BoostRunClub/Views/DataSource/ActivityDataSource.swift
+++ b/BoostRunClub/Views/DataSource/ActivityDataSource.swift
@@ -7,13 +7,43 @@
 
 import UIKit
 
-class ActivityDataSource: NSObject, UICollectionViewDataSource {
-    var activities = [Activity]()
+class ActivityDataSource: NSObject {
+    private(set) var activities = [Activity]()
+    private(set) var statisticHeaderTitle = ""
+    private(set) var activityTotal = ActivityTotalConfig()
 
-    func loadData(_ activities: [Activity]) {
+    private(set) lazy var containerCellView = ActivitiesContainerCellView()
+    private var activityStatisticCells: [ActivityStatisticCellView] = [
+        ActivityStatisticCellView(),
+        ActivityStatisticCellView(),
+        ActivityStatisticCellView(),
+        ActivityStatisticCellView(),
+        ActivityStatisticCellView(),
+    ]
+
+    func loadActivities(_ activities: [Activity]) {
         self.activities = activities
     }
 
+    func loadActivityTotal(_ config: ActivityTotalConfig) {
+        switch config.filterType {
+        case .week, .month:
+            statisticHeaderTitle = ""
+        case .all, .year:
+            statisticHeaderTitle = config.filterType == .all ? "총 활동 통계" : config.period + " 통계"
+        }
+
+        activityStatisticCells[0].configure(title: "러닝", value: config.numRunningPerWeekText)
+        activityStatisticCells[1].configure(title: "킬로미터", value: config.distancePerRunningText)
+        activityStatisticCells[2].configure(title: "러닝페이스", value: config.avgPaceText)
+        activityStatisticCells[3].configure(title: "시간", value: config.runningTimePerRunningText)
+        activityStatisticCells[4].configure(title: "고도 상승", value: config.totalElevationText)
+    }
+}
+
+// MARK: - UICollectionViewDataSource Implementation
+
+extension ActivityDataSource: UICollectionViewDataSource {
     func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
         return activities.count
     }
@@ -27,5 +57,31 @@ class ActivityDataSource: NSObject, UICollectionViewDataSource {
         ) as? ActivityCellView
         cell?.configure(with: activities[indexPath.row])
         return cell ?? UICollectionViewCell()
+    }
+}
+
+// MARK: - UITableViewDataSource Implementation
+
+extension ActivityDataSource: UITableViewDataSource {
+    func numberOfSections(in _: UITableView) -> Int {
+        statisticHeaderTitle.isEmpty ? 1 : 2
+    }
+
+    func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if statisticHeaderTitle.isEmpty {
+            return 1
+        } else {
+            return section == 0 ? 5 : 1
+        }
+    }
+
+    func tableView(_: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if !statisticHeaderTitle.isEmpty,
+           indexPath.section == 0
+        {
+            return activityStatisticCells[indexPath.row]
+        } else {
+            return containerCellView
+        }
     }
 }

--- a/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
+++ b/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
@@ -51,7 +51,13 @@ class ActivityDetailDataSource: NSObject, UITableViewDataSource {
             let paceText = String(format: "%d'%d\"", split.avgPace / 60, split.avgPace % 60)
             let elevationText = String(split.elevation)
 
-            let paceRatio = maxPace == 0 ? 0 : (maxPace - CGFloat(split.avgPace)) / (maxPace - minPace)
+            let paceRatio: CGFloat
+            if maxPace - minPace > 0 {
+                paceRatio = (maxPace - CGFloat(split.avgPace)) / (maxPace - minPace)
+            } else {
+                paceRatio = 0
+            }
+
             cell.configure(
                 style: .value,
                 distance: distanceText,

--- a/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
+++ b/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
@@ -9,13 +9,20 @@ import UIKit
 
 class ActivityDetailDataSource: NSObject, UITableViewDataSource {
     private var maxPace: CGFloat = 0
+    private var minPace: CGFloat = 0
     private var splits = [RunningSplit]()
     private var totalDistance: Double = 0
 
     func loadData(splits: [RunningSplit], distance: Double) {
         self.splits = splits
         totalDistance = distance
-        maxPace = splits.reduce(into: 0) { $0 = max($0, CGFloat($1.avgPace)) }
+        let minMaxValue = splits.reduce(into: (min: CGFloat.infinity, max: CGFloat(0))) {
+            let value = CGFloat($1.avgPace)
+            $0.max = max($0.max, value)
+            $0.min = min($0.min, value)
+        }
+        maxPace = minMaxValue.max
+        minPace = minMaxValue.min
     }
 
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
@@ -44,8 +51,7 @@ class ActivityDetailDataSource: NSObject, UITableViewDataSource {
             let paceText = String(format: "%d'%d\"", split.avgPace / 60, split.avgPace % 60)
             let elevationText = String(split.elevation)
 
-            let paceRatio = maxPace == 0 ? 0 : (maxPace - CGFloat(split.avgPace)) / maxPace
-
+            let paceRatio = maxPace == 0 ? 0 : (maxPace - CGFloat(split.avgPace)) / (maxPace - minPace)
             cell.configure(
                 style: .value,
                 distance: distanceText,

--- a/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
+++ b/BoostRunClub/Views/DataSource/ActivityDetailDataSource.swift
@@ -11,6 +11,7 @@ class ActivityDetailDataSource: NSObject, UITableViewDataSource {
     private var maxPace: CGFloat = 0
     private var splits = [RunningSplit]()
     private var totalDistance: Double = 0
+
     func loadData(splits: [RunningSplit], distance: Double) {
         self.splits = splits
         totalDistance = distance
@@ -33,7 +34,13 @@ class ActivityDetailDataSource: NSObject, UITableViewDataSource {
             let idx = indexPath.row - 1
             let split = splits[idx]
 
-            let distanceText = idx < splits.count - 1 ? "\(idx + 1)" : String(format: "%.2f", Double(Int(totalDistance) % 1000) / 1000)
+            let distanceText: String
+            if idx < splits.count - 1 {
+                distanceText = "\(idx + 1)"
+            } else {
+                distanceText = String(format: "%.2f", Double(Int(totalDistance) % 1000) / 1000)
+            }
+
             let paceText = String(format: "%d'%d\"", split.avgPace / 60, split.avgPace % 60)
             let elevationText = String(split.elevation)
 


### PR DESCRIPTION
### Issue Number
Close #142 

### 변경사항

- ActivityDataSource로 ActivityScene의 CollectionView, TableView DataSource 이동
- SimpleSplitCell
- `configureLayout` 함수에 한해 swiftLint "function_body_length" 예외처리
- test 파일에 한해 swiftLint의 "body_length" "file_length" 예외처리
- 그 밖에 TODO를 제외한 swiftLint 경고 처리

### 새로운 기능
- SimpleSplitCell의 avgPace별 수치를 배경에 그래프로 나타낼 수 있도록 수정


### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
