### PR TITLE
(#189) style: 다크모드 컬러셋 추가 및 적용

### DIFF
--- a/BoostRunClub/Extensions/UIButton+setArrowImage.swift
+++ b/BoostRunClub/Extensions/UIButton+setArrowImage.swift
@@ -12,7 +12,7 @@ extension UIButton {
         case left, right
     }
 
-    func setArrowImage(dir: ArrowDirection, color: UIColor = .label) {
+    func setArrowImage(dir: ArrowDirection, color: UIColor = .black) {
         let arrow = UIImage(systemName: "arrow.\(dir.rawValue)")
         setImage(arrow, for: .normal)
         switch dir {

--- a/BoostRunClub/SupportingFiles/Assets.xcassets/Accent.colorset/Contents.json
+++ b/BoostRunClub/SupportingFiles/Assets.xcassets/Accent.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.932",
+          "red" : "0.976"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostRunClub/SupportingFiles/Assets.xcassets/Color.colorset/Contents.json
+++ b/BoostRunClub/SupportingFiles/Assets.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostRunClub/SupportingFiles/Assets.xcassets/accent2.colorset/Contents.json
+++ b/BoostRunClub/SupportingFiles/Assets.xcassets/accent2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.932",
+          "red" : "0.976"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostRunClub/SupportingFiles/Assets.xcassets/brcYellow.colorset/Contents.json
+++ b/BoostRunClub/SupportingFiles/Assets.xcassets/brcYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.932",
+          "red" : "0.976"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.260",
+          "green" : "0.777",
+          "red" : "0.800"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostRunClub/Views/CircleButton.swift
+++ b/BoostRunClub/Views/CircleButton.swift
@@ -23,25 +23,30 @@ class CircleButton: UIButton {
     }
 
     private func commonInit(with buttonStyle: Style = .start) {
+        setTitleColor(.label, for: .normal)
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 25)
+        imageView?.contentMode = .scaleAspectFill
+
         switch buttonStyle {
         case .start:
-            backgroundColor = #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
+            backgroundColor = UIColor(named: "accent")
             setTitle("시작", for: .normal)
+            setTitleColor(UIColor(named: "accent2"), for: .normal)
         case .stop:
             setSFSymbol(iconName: "stop.fill", size: 25, tintColor: .systemBackground, backgroundColor: .label)
         case .pause:
             setSFSymbol(iconName: "pause.fill", size: 25, tintColor: .systemBackground, backgroundColor: .label)
+            setTitleColor(UIColor(named: "accent2"), for: .normal)
         case .resume:
-            setSFSymbol(iconName: "play.fill", size: 25, tintColor: .label, backgroundColor: #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1))
+            setSFSymbol(iconName: "play.fill",
+                        size: 25,
+                        tintColor: .label,
+                        backgroundColor: UIColor(named: "brcYellow")!)
         case .locate:
             setSFSymbol(iconName: "location.fill", size: 25, tintColor: .systemBackground, backgroundColor: .label)
         case .exit:
             setSFSymbol(iconName: "xmark", size: 25, tintColor: .systemBackground, backgroundColor: .label)
         }
-
-        setTitleColor(.label, for: .normal)
-        titleLabel?.font = UIFont.boldSystemFont(ofSize: 25)
-        imageView?.contentMode = .scaleAspectFill
     }
 
     override func layoutSubviews() {

--- a/BoostRunClub/Views/Controllers/PausedRunningViewController.swift
+++ b/BoostRunClub/Views/Controllers/PausedRunningViewController.swift
@@ -132,7 +132,7 @@ extension PausedRunningViewController {
         mapViewHeightConstraint.constant = .zero
         resumeButtonInitialCenterXConstraint.constant = .zero
         endRunningButtonInitialCenterXConstraint.constant = .zero
-        view.backgroundColor = #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
+        view.backgroundColor = UIColor(named: "accent")
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
             self.view.layoutIfNeeded()
         } completion: { _ in

--- a/BoostRunClub/Views/Controllers/RunningInfoViewController.swift
+++ b/BoostRunClub/Views/Controllers/RunningInfoViewController.swift
@@ -74,7 +74,7 @@ final class RunningInfoViewController: UIViewController {
 extension RunningInfoViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
+        view.backgroundColor = UIColor(named: "accent")
         configureLayout()
         bindViewModel()
     }

--- a/BoostRunClub/Views/Controllers/RunningPageViewController.swift
+++ b/BoostRunClub/Views/Controllers/RunningPageViewController.swift
@@ -171,7 +171,7 @@ extension RunningPageViewController {
     func makeBackButton() -> UIButton {
         let button = UIButton()
         button.backgroundColor = #colorLiteral(red: 0.9763557315, green: 0.9324046969, blue: 0, alpha: 1)
-        button.setTitleColor(.label, for: .normal)
+        button.setTitleColor(.black, for: .normal)
         button.layer.cornerRadius = buttonHeight / 2
         button.addTarget(self, action: #selector(didTabBackButton), for: .touchUpInside)
         return button

--- a/BoostRunClub/Views/RunDataView.swift
+++ b/BoostRunClub/Views/RunDataView.swift
@@ -88,7 +88,7 @@ extension RunDataView {
             label = UILabel()
             label.font = UIFont.boldSystemFont(ofSize: 17)
         }
-        label.textColor = .black
+        label.textColor = UIColor(named: "accent2")
         label.textAlignment = .center
         label.text = "00:00"
         return label


### PR DESCRIPTION
### Issue Number
Close #189

### 변경사항

- 러닝 준비화면의 <시작 버튼> 컬러 
- 러닝 화면의 <러닝 데이터> 컬러, <배경> 컬러
- 일시정지 화면의 <러닝 재시작 버튼> 컬러

- "accent", "accent2", "brcYellow" color set 추가

### 새로운 기능

- 기능 목록

### 작업 유형
- [] 신규 기능 추가
- [ ] 버그 수정
- [X] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
